### PR TITLE
Format API response

### DIFF
--- a/aio/aio-proxy/aio_proxy/response.py
+++ b/aio/aio-proxy/aio_proxy/response.py
@@ -18,19 +18,19 @@ def api_response(
         extract_function (Callable): function used to extract parameters.
         search_function (Callable): function used for search .
     Returns:
-        response in json format (unite_legale, total_results, page, per_page,
+        response in json format (results, total_results, page, per_page,
         total_pages)
     """
     parameters, page, per_page = extract_function(request)
-    total_results, unite_legale = search_function(
+    total_results, results = search_function(
         Siren, page * per_page, per_page, **parameters
     )
-    unite_legale_filtered = hide_fields(unite_legale)
+    results_filtered = hide_fields(results)
     res = {
-        "unite_legale": unite_legale_filtered,
+        "results": results_filtered,
         "total_results": int(total_results),
         "page": page + 1,
         "per_page": per_page,
     }
     res["total_pages"] = int(res["total_results"] / res["per_page"]) + 1
-    return web.json_response(text=json.dumps([res], default=str))
+    return web.json_response(text=json.dumps(res, default=str))

--- a/aio/aio-proxy/aio_proxy/search/helpers.py
+++ b/aio/aio-proxy/aio_proxy/search/helpers.py
@@ -30,6 +30,7 @@ def hide_fields(search_result: list) -> list:
         "coordonnees",
         "concat_nom_adr_siren",
         "concat_enseigne_adresse",
+        "geo_adresse",
         "is_siege",
         "liste_adresse",
         "liste_enseigne",

--- a/aio/aio-proxy/aio_proxy/search/helpers.py
+++ b/aio/aio-proxy/aio_proxy/search/helpers.py
@@ -13,7 +13,7 @@ def sort_and_execute_search(search, offset: int, page_size: int) -> Tuple:
     search = search.extra(track_scores=True)
     search = search.sort(
         {"_score": {"order": "desc"}},
-        {"etat_administratif_etablissement": {"order": "asc"}},
+        {"etat_administratif_unite_legale": {"order": "asc"}},
     )
     search = search[offset : (offset + page_size)]
     results = search.execute()
@@ -27,13 +27,15 @@ def sort_and_execute_search(search, offset: int, page_size: int) -> Tuple:
 def hide_fields(search_result: list) -> list:
     """Hide concatenation fields in search results."""
     hidden_fields = {
+        "coordonnees",
         "concat_nom_adr_siren",
         "concat_enseigne_adresse",
+        "is_siege",
         "liste_adresse",
         "liste_enseigne",
     }
-    unite_legale = [
+    results = [
         {field: value for field, value in unite.items() if field not in hidden_fields}
         for unite in search_result
     ]
-    return unite_legale
+    return results

--- a/aio/aio-proxy/aio_proxy/search/helpers.py
+++ b/aio/aio-proxy/aio_proxy/search/helpers.py
@@ -13,7 +13,7 @@ def sort_and_execute_search(search, offset: int, page_size: int) -> Tuple:
     search = search.extra(track_scores=True)
     search = search.sort(
         {"_score": {"order": "desc"}},
-        {"etat_administratif_unite_legale": {"order": "asc"}},
+        {"etat_administratif_siege": {"order": "asc"}},
     )
     search = search[offset : (offset + page_size)]
     results = search.execute()

--- a/aio/aio-proxy/aio_proxy/search/search_functions.py
+++ b/aio/aio-proxy/aio_proxy/search/search_functions.py
@@ -20,7 +20,7 @@ def search_text(index, offset: int, page_size: int, **kwargs):
                             fields=[
                                 "nom_complet^15",
                                 "siren^3",
-                                "siret^3",
+                                "siret_siege^3",
                                 "identifiantAssociationUniteLegale^3",
                             ],
                         )
@@ -29,7 +29,7 @@ def search_text(index, offset: int, page_size: int, **kwargs):
                 functions=[
                     query.SF(
                         "field_value_factor",
-                        field="nombre_etablissements_ouvert",
+                        field="nombre_etablissements_ouverts",
                         factor=10,
                         modifier="sqrt",
                         missing=1,
@@ -52,7 +52,7 @@ def search_text(index, offset: int, page_size: int, **kwargs):
                 functions=[
                     query.SF(
                         "field_value_factor",
-                        field="nombre_etablissements_ouvert",
+                        field="nombre_etablissements_ouverts",
                         factor=10,
                         modifier="sqrt",
                         missing=1,
@@ -69,7 +69,7 @@ def search_text(index, offset: int, page_size: int, **kwargs):
                             fields=[
                                 "nom_complet^7",
                                 "siren^7",
-                                "siret^4",
+                                "siret_siege^4",
                                 "identifiantAssociationUniteLegale^4",
                             ],
                             operator="and",
@@ -79,7 +79,7 @@ def search_text(index, offset: int, page_size: int, **kwargs):
                 functions=[
                     query.SF(
                         "field_value_factor",
-                        field="nombre_etablissements_ouvert",
+                        field="nombre_etablissements_ouverts",
                         factor=10,
                         modifier="sqrt",
                         missing=1,
@@ -101,7 +101,7 @@ def search_text(index, offset: int, page_size: int, **kwargs):
                 functions=[
                     query.SF(
                         "field_value_factor",
-                        field="nombre_etablissements_ouvert",
+                        field="nombre_etablissements_ouverts",
                         factor=10,
                         modifier="sqrt",
                         missing=1,
@@ -124,7 +124,7 @@ def search_text(index, offset: int, page_size: int, **kwargs):
                 functions=[
                     query.SF(
                         "field_value_factor",
-                        field="nombre_etablissements_ouvert",
+                        field="nombre_etablissements_ouverts",
                         factor=10,
                         modifier="sqrt",
                         missing=1,


### PR DESCRIPTION
closes #22 
* Change response variable names to be more accurate
* Change response format to dict instead of array
* Remove useless variables from response
