### PR TITLE
Fix: add return keyword to get_field function

### DIFF
--- a/aio/aio-proxy/aio_proxy/response/format_response.py
+++ b/aio/aio-proxy/aio_proxy/response/format_response.py
@@ -7,7 +7,7 @@ def format_response(results):
     for result in results:
 
         def get_field(field, default=None):
-            get_value(result, field, default)
+            return get_value(result, field, default)
 
         result_formatted = {
             "siren": get_field("siren"),


### PR DESCRIPTION
Error: API returns null values for all fields.