### PR TITLE
Add 'section activaté principle' filter to API

### DIFF
--- a/aio/aio-proxy/aio_proxy/doc/open-api.yml
+++ b/aio/aio-proxy/aio_proxy/doc/open-api.yml
@@ -59,7 +59,8 @@ paths:
 
 
         **Paramètres d'appel :** dénomination de l'entreprise, code postal, activité 
-        principale de l'entreprise, entrepreneur individuel et tranche d'effectif 
+        principale et section d'activité principale de l'entreprise, entrepreneur 
+        individuel et tranche d'effectif 
         salarié.
 
 
@@ -83,6 +84,58 @@ paths:
           required: false
           schema:
             type: string
+        - name: section_activite_principale
+          in: query
+          description: |
+            <a href=https://www.insee.fr/fr/information/2120875>Section de 
+            l'activité principale :</a>
+            
+              * `A` - Agriculture, sylviculture et pêche
+              * `B` - Industries extractives
+              * `C` - Industrie manufacturière
+              * `D` - Production et distribution d'électricité, de gaz, de vapeur et d'air conditionné
+              * `E` - Production et distribution d'eau ; assainissement, gestion des déchets et dépollution
+              * `F` -  Construction
+              * `G` -  Commerce ; réparation d'automobiles et de motocycles
+              * `H` -  Transports et entreposage
+              * `I` -  Hébergement et restauration
+              * `J` -  Information et communication
+              * `K` -  Activités financières et d'assurance
+              * `L` -  Activités immobilières
+              * `M` -  Activités spécialisées, scientifiques et techniques
+              * `N` -  Activités de services administratifs et de soutien
+              * `O` -  Administration publique
+              * `P` -  Enseignement
+              * `Q` -  Santé humaine et action sociale
+              * `R` -  Arts, spectacles et activités récréatives
+              * `S` -  Autres activités de services
+              * `T` -  Activités des ménages en tant qu'employeurs ; activités indifférenciées des ménages en tant que producteurs de biens et services pour usage propre
+              * `U` -  Activités extra-territoriales
+          schema:
+            type: string
+            enum:
+              - A
+              - B
+              - C
+              - D
+              - E
+              - F
+              - G
+              - H
+              - I
+              - J
+              - K
+              - L
+              - M
+              - N
+              - O
+              - P
+              - Q
+              - R
+              - S
+              - T
+              - U
+            maxLength: 1
         - name: is_entrepreneur_individuel
           in: query
           description: Uniquement les entreprises individuelles
@@ -192,6 +245,8 @@ paths:
                           type: string
                         activite_principale:
                           type: string
+                        section_activite_principale:
+                          type: string
                         economie_sociale_solidaire:
                           type: string
                         nom_complet:
@@ -236,8 +291,8 @@ paths:
         Vous pouvez également préciser un paramètre radius en km(défaut: 5 km).
         
         
-        **Paramètres d'appel :** latitude, longitude, radius et activité principale
-        de l'entreprise.
+        **Paramètres d'appel :** latitude, longitude, radius, activité principale
+        et section d'activité principale de l'entreprise.
         
 
       summary: Recherche géographique
@@ -270,6 +325,57 @@ paths:
           required: false
           schema:
             type: string
+        - name: section_activite_principale
+          in: query
+          description: |
+            <a href=https://www.insee.fr/fr/information/2120875>Section de 
+            l'activité principale :</a>
+              * `A` - Agriculture, sylviculture et pêche
+              * `B` - Industries extractives
+              * `C` - Industrie manufacturière
+              * `D` - Production et distribution d'électricité, de gaz, de vapeur et d'air conditionné
+              * `E` - Production et distribution d'eau ; assainissement, gestion des déchets et dépollution
+              * `F` -  Construction
+              * `G` -  Commerce ; réparation d'automobiles et de motocycles
+              * `H` -  Transports et entreposage
+              * `I` -  Hébergement et restauration
+              * `J` -  Information et communication
+              * `K` -  Activités financières et d'assurance
+              * `L` -  Activités immobilières
+              * `M` -  Activités spécialisées, scientifiques et techniques
+              * `N` -  Activités de services administratifs et de soutien
+              * `O` -  Administration publique
+              * `P` -  Enseignement
+              * `Q` -  Santé humaine et action sociale
+              * `R` -  Arts, spectacles et activités récréatives
+              * `S` -  Autres activités de services
+              * `T` -  Activités des ménages en tant qu'employeurs ; activités indifférenciées des ménages en tant que producteurs de biens et services pour usage propre
+              * `U` -  Activités extra-territoriales
+          schema:
+            type: string
+            enum:
+              - A
+              - B
+              - C
+              - D
+              - E
+              - F
+              - G
+              - H
+              - I
+              - J
+              - K
+              - L
+              - M
+              - N
+              - O
+              - P
+              - Q
+              - R
+              - S
+              - T
+              - U
+            maxLength: 1
         - name: page
           in: query
           description: Le numéro de la page à retourner
@@ -363,6 +469,8 @@ paths:
                         nature_juridique:
                           type: string
                         activite_principale:
+                          type: string
+                        section-activite_principale:
                           type: string
                         economie_sociale_solidaire:
                           type: string

--- a/aio/aio-proxy/aio_proxy/labels/helpers.py
+++ b/aio/aio-proxy/aio_proxy/labels/helpers.py
@@ -11,3 +11,4 @@ def load_file(file_name: str):
 
 codes_naf = load_file("codes-NAF.json")
 tranches_effectifs = load_file("tranches-effectifs.json")
+sections_codes_naf = load_file("sections-codes-NAF.json")

--- a/aio/aio-proxy/aio_proxy/labels/sections-codes-NAF.json
+++ b/aio/aio-proxy/aio_proxy/labels/sections-codes-NAF.json
@@ -1,0 +1,23 @@
+{
+  "A":"Agriculture, sylviculture et pêche",
+  "B":"Industries extractives",
+  "C":"Industrie manufacturière",
+  "D":"Production et distribution d'électricité, de gaz, de vapeur et d'air conditionné",
+  "E":"Production et distribution d'eau ; assainissement, gestion des déchets et dépollution",
+  "F":"Construction",
+  "G":"Commerce; réparation d'automobiles et de motocycles",
+  "H":"Transports et entreposage",
+  "I":"Hébergement et restauration",
+  "J":"Information et communication",
+  "K":"Activités financières et d'assurance",
+  "L":"Activités immobilières",
+  "M":"Activités spécialisées, scientifiques et techniques",
+  "N":"Activités de services administratifs et de soutien",
+  "O":"Administration publique",
+  "P":"Enseignement",
+  "Q":"Santé humaine et action sociale",
+  "R":"Arts, spectacles et activités récréatives",
+  "S":"Autres activités de services",
+  "T":"Activités des ménages en tant qu'employeurs ; activités indifférenciées des ménages en tant que producteurs de biens et services pour usage propre",
+  "U":"Activités extra-territoriales"
+}

--- a/aio/aio-proxy/aio_proxy/parsers/section_activite_principale.py
+++ b/aio/aio-proxy/aio_proxy/parsers/section_activite_principale.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+from aio_proxy.labels.helpers import sections_codes_naf
+
+
+def validate_section_activite_principale(
+    section_activite_principale_clean: str,
+) -> Optional[str]:
+    """Check the validity of section_activite_principale.
+
+    Args:
+        section_activite_principale_clean(str, optional):
+        section_activite_principale extracted and cleaned.
+
+    Returns:
+        None if section_activite_principale_clean is None.
+        section_activite_principale_clean if valid.
+
+    Raises:
+        ValueError: if section_activite_principale_clean not valid.
+    """
+    if section_activite_principale_clean is None:
+        return None
+    if section_activite_principale_clean not in sections_codes_naf:
+        raise ValueError("Section d'activité principale non valide.")
+    return section_activite_principale_clean

--- a/aio/aio-proxy/aio_proxy/response/format_response.py
+++ b/aio/aio-proxy/aio_proxy/response/format_response.py
@@ -42,6 +42,7 @@ def format_response(results):
             "nom_raison_sociale": get_field("nom_raison_sociale"),
             "nature_juridique": get_field("nature_juridique_unite_legale"),
             "activite_principale": get_field("activite_principale_unite_legale"),
+            "section_activite_principale": get_field("section_activite_principale"),
             "economie_sociale_solidaire": get_field(
                 "economie_sociale_solidaire_unite_legale"
             ),

--- a/aio/aio-proxy/aio_proxy/response/parameters.py
+++ b/aio/aio-proxy/aio_proxy/response/parameters.py
@@ -10,6 +10,9 @@ from aio_proxy.parsers.longitude import parse_and_validate_longitude
 from aio_proxy.parsers.page import parse_and_validate_page
 from aio_proxy.parsers.per_page import parse_and_validate_per_page
 from aio_proxy.parsers.radius import parse_and_validate_radius
+from aio_proxy.parsers.section_activite_principale import (
+    validate_section_activite_principale,
+)
 from aio_proxy.parsers.string_parser import parse_and_clean_parameter
 from aio_proxy.parsers.terms import parse_and_validate_terms
 from aio_proxy.parsers.tranche_effectif import (
@@ -46,6 +49,9 @@ def extract_text_parameters(
     is_entrepreneur_individuel = validate_is_entrepreneur_individuel(
         parse_and_clean_parameter(request, param="is_entrepreneur_individuel")
     )
+    section_activite_principale = validate_section_activite_principale(
+        parse_and_clean_parameter(request, param="section_activite_principale")
+    )
     tranche_effectif_salarie = validate_tranche_effectif_salarie(
         parse_and_clean_parameter(request, param="tranche_effectif_salarie")
     )
@@ -54,6 +60,7 @@ def extract_text_parameters(
         "activite_principale_unite_legale": activite_principale,
         "code_postal": code_postal,
         "is_entrepreneur_individuel": is_entrepreneur_individuel,
+        "section_activite_principale": section_activite_principale,
         "tranche_effectif_salarie_unite_legale": tranche_effectif_salarie,
     }
 
@@ -69,10 +76,14 @@ def extract_geo_parameters(request):
     activite_principale = validate_activite_principale(
         parse_and_clean_parameter(request, param="activite_principale")
     )
+    section_activite_principale = validate_section_activite_principale(
+        parse_and_clean_parameter(request, param="section_activite_principale")
+    )
     parameters = {
         "lat": lat,
         "lon": lon,
         "radius": radius,
         "activite_principale_unite_legale": activite_principale,
+        "section_activite_principale": section_activite_principale,
     }
     return parameters, page, per_page

--- a/aio/aio-proxy/aio_proxy/tests/test_section_activite_principale.py
+++ b/aio/aio-proxy/aio_proxy/tests/test_section_activite_principale.py
@@ -1,0 +1,22 @@
+import pytest
+from aio_proxy.parsers.section_activite_principale import (
+    validate_section_activite_principale,
+)
+
+
+@pytest.mark.parametrize(
+    "section_activite_principale, expected",
+    [("A", "A"), ("l", "l"), (None, None)],
+)
+def test_validate_section_activite_principale(
+    section_activite_principale: str, expected: str
+):
+    assert validate_section_activite_principale(section_activite_principale) == expected
+
+
+@pytest.mark.parametrize("section_activite_principale", ["Z", "68.20B"])
+def test_validate_section_activite_principale_fail(
+    section_activite_principale: str,
+):
+    with pytest.raises(ValueError, match="Section d'activité principale non valide."):
+        validate_section_activite_principale(section_activite_principale)

--- a/aio/aio-proxy/aio_proxy/tests/test_section_activite_principale.py
+++ b/aio/aio-proxy/aio_proxy/tests/test_section_activite_principale.py
@@ -6,7 +6,7 @@ from aio_proxy.parsers.section_activite_principale import (
 
 @pytest.mark.parametrize(
     "section_activite_principale, expected",
-    [("A", "A"), ("l", "L"), (None, None)],
+    [("A", "A"), (None, None)],
 )
 def test_validate_section_activite_principale(
     section_activite_principale: str, expected: str

--- a/aio/aio-proxy/aio_proxy/tests/test_section_activite_principale.py
+++ b/aio/aio-proxy/aio_proxy/tests/test_section_activite_principale.py
@@ -6,7 +6,7 @@ from aio_proxy.parsers.section_activite_principale import (
 
 @pytest.mark.parametrize(
     "section_activite_principale, expected",
-    [("A", "A"), ("l", "l"), (None, None)],
+    [("A", "A"), ("l", "L"), (None, None)],
 )
 def test_validate_section_activite_principale(
     section_activite_principale: str, expected: str


### PR DESCRIPTION
closes #34 
depends on https://github.com/etalab/data-engineering-stack/pull/15
depends on https://github.com/etalab/annuaire-entreprises-search-infra/pull/15

👉 **SIDE NOTE**: 
I could not find a way to use enum with named items for `section_activite_principale` parameter in swagger.
Consequently, I added corresponding descriptions in parameter description instead. 
Issues discussing this : 
https://github.com/OAI/OpenAPI-Specification/issues/681
https://github.com/json-schema-org/json-schema-spec/issues/1062
https://github.com/json-schema-org/json-schema-spec/issues/57