### PR TITLE
Decrease aio logging level

### DIFF
--- a/aio/aio-proxy/aio_proxy/main.py
+++ b/aio/aio-proxy/aio_proxy/main.py
@@ -12,7 +12,7 @@ open_api_path = BASE_DIR / "aio_proxy" / "doc" / "open-api.yml"
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.INFO)
     logging.info("********Starting API")
 
     app = web.Application()

--- a/aio/aio-proxy/aio_proxy/search/helpers.py
+++ b/aio/aio-proxy/aio_proxy/search/helpers.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 
 def get_current_color(color_url):


### PR DESCRIPTION
AIO container has too many logs which renders them unreadable.
We switch the logging level from `DEBUG` to  `INFO` for better readability.