### PR TITLE
Add APM support in sentry

### DIFF
--- a/aio/aio-proxy/aio_proxy/routes.py
+++ b/aio/aio-proxy/aio_proxy/routes.py
@@ -23,7 +23,10 @@ DSN_SENTRY = os.getenv("DSN_SENTRY")
 
 # Connect to Sentry in production
 if ENV == "prod":
-    sentry_sdk.init(dsn=DSN_SENTRY, integrations=[AioHttpIntegration()])
+    sentry_sdk.init(dsn=DSN_SENTRY, 
+    integrations=[AioHttpIntegration(transaction_style="method_and_path_pattern")],
+    # we log 10% of transactions for performance monitoring
+    traces_sample_rate=0.1)
 
 # Connect to Elasticsearch
 connections.create_connection(

--- a/aio/aio-proxy/aio_proxy/routes.py
+++ b/aio/aio-proxy/aio_proxy/routes.py
@@ -24,7 +24,7 @@ DSN_SENTRY = os.getenv("DSN_SENTRY")
 # Connect to Sentry in production
 if ENV == "prod":
     sentry_sdk.init(
-        dsn=DSN_SENTRY, 
+        dsn=DSN_SENTRY,
         integrations=[AioHttpIntegration(transaction_style="method_and_path_pattern")],
         # we log 10% of transactions for performance monitoring
         traces_sample_rate=0.1,

--- a/aio/aio-proxy/aio_proxy/routes.py
+++ b/aio/aio-proxy/aio_proxy/routes.py
@@ -23,10 +23,12 @@ DSN_SENTRY = os.getenv("DSN_SENTRY")
 
 # Connect to Sentry in production
 if ENV == "prod":
-    sentry_sdk.init(dsn=DSN_SENTRY, 
-    integrations=[AioHttpIntegration(transaction_style="method_and_path_pattern")],
-    # we log 10% of transactions for performance monitoring
-    traces_sample_rate=0.1)
+    sentry_sdk.init(
+        dsn=DSN_SENTRY, 
+        integrations=[AioHttpIntegration(transaction_style="method_and_path_pattern")],
+        # we log 10% of transactions for performance monitoring
+        traces_sample_rate=0.1,
+    )
 
 # Connect to Elasticsearch
 connections.create_connection(


### PR DESCRIPTION
I dont have API locally installed so I let @geoffreyaldebert try it.

I followed the sentry documentation to log 10% of API call : 
https://docs.sentry.io/platforms/python/guides/aiohttp/

And use a generic grouping of transactions by route :
https://docs.sentry.io/platforms/python/guides/aiohttp/#options