### PR TITLE
ops: increase elasticsearch jvm memory to 8g

### DIFF
--- a/docker-compose-elastic.yml
+++ b/docker-compose-elastic.yml
@@ -12,7 +12,7 @@ services:
       - node.name=elastic-sirene
       - cluster.name=es-docker-cluster
       - discovery.type=single-node
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
+      - "ES_JAVA_OPTS=-Xms8g -Xmx8g -Dlog4j2.formatMsgNoLookups=true"
       - xpack.security.enabled=true
       - ELASTICSEARCH_PORT=9200
       - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}


### PR DESCRIPTION
Desperate times calls for desperate measures...
I need to merge this, otherwise I won't be able to index in staging for performance tests tomorrow 😬

Once again the E2E tests rely on `dev` indices to test the API, and since the indices in the dev are currently the `établissements` ones , the tests logically do not pass.
Once the `établissements` search PR is merged, this problem will be solved for the following PRs.