### PR TITLE
Format la réponse API (les établissements)

### DIFF
--- a/aio/aio-proxy/aio_proxy/response/format_search_results.py
+++ b/aio/aio-proxy/aio_proxy/response/format_search_results.py
@@ -27,19 +27,19 @@ def format_search_results(results, include_etablissements=False):
                 get_field("nombre_etablissements_ouverts", default=0)
             ),
             "siege": format_siege(get_field("siege")),
-            "date_creation": get_field("date_creation_unite_legale"),
-            "tranche_effectif_salarie": get_field(
-                "tranche_effectif_salarie_unite_legale"
-            ),
-            "date_mise_a_jour": get_field("date_mise_a_jour_unite_legale"),
-            "categorie_entreprise": get_field("categorie_entreprise"),
-            "etat_administratif": get_field("etat_administratif_unite_legale"),
-            "nom_raison_sociale": get_field("nom_raison_sociale"),
-            "nature_juridique": get_field("nature_juridique_unite_legale"),
             "activite_principale": get_field("activite_principale_unite_legale"),
-            "section_activite_principale": get_field("section_activite_principale"),
+            "categorie_entreprise": get_field("categorie_entreprise"),
+            "date_creation": get_field("date_creation_unite_legale"),
+            "date_mise_a_jour": get_field("date_mise_a_jour_unite_legale"),
             "dirigeants": format_dirigeants(
                 get_field("dirigeants_pp"), get_field("dirigeants_pm")
+            ),
+            "etat_administratif": get_field("etat_administratif_unite_legale"),
+            "nature_juridique": get_field("nature_juridique_unite_legale"),
+            "nom_raison_sociale": get_field("nom_raison_sociale"),
+            "section_activite_principale": get_field("section_activite_principale"),
+            "tranche_effectif_salarie": get_field(
+                "tranche_effectif_salarie_unite_legale"
             ),
             "matching_etablissements": format_etablissements_list(
                 get_field("matching_etablissements")

--- a/aio/aio-proxy/aio_proxy/response/formatters/enseignes.py
+++ b/aio/aio-proxy/aio_proxy/response/formatters/enseignes.py
@@ -1,2 +1,4 @@
 def format_enseignes(enseignes):
+    if not enseignes:
+        return None
     return [enseigne for enseigne in enseignes if enseigne is not None]

--- a/aio/aio-proxy/aio_proxy/response/formatters/enseignes.py
+++ b/aio/aio-proxy/aio_proxy/response/formatters/enseignes.py
@@ -1,0 +1,2 @@
+def format_enseignes(enseignes):
+    return [enseigne for enseigne in enseignes if enseigne is not None]

--- a/aio/aio-proxy/aio_proxy/response/formatters/etablissements.py
+++ b/aio/aio-proxy/aio_proxy/response/formatters/etablissements.py
@@ -8,13 +8,16 @@ def format_etablissement(source_etablissement):
         "activite_principale_registre_metier": get_value(
             source_etablissement, "activite_principale_registre_metier"
         ),
+        "adresse": get_value(source_etablissement, "adresse"),
         "cedex": get_value(source_etablissement, "cedex"),
         "code_pays_etranger": get_value(source_etablissement, "code_pays_etranger"),
         "code_postal": get_value(source_etablissement, "code_postal"),
         "commune": get_value(source_etablissement, "commune"),
         "complement_adresse": get_value(source_etablissement, "complement_adresse"),
+        "coordonnees": get_value(source_etablissement, "coordonnees"),
         "date_creation": get_value(source_etablissement, "date_creation"),
         "date_debut_activite": get_value(source_etablissement, "date_debut_activite"),
+        "departement": get_value(source_etablissement, "departement"),
         "distribution_speciale": get_value(
             source_etablissement, "distribution_speciale"
         ),
@@ -52,9 +55,6 @@ def format_etablissement(source_etablissement):
             source_etablissement, "tranche_effectif_salarie"
         ),
         "type_voie": get_value(source_etablissement, "type_voie"),
-        "adresse": get_value(source_etablissement, "adresse"),
-        "coordonnees": get_value(source_etablissement, "coordonnees"),
-        "departement": get_value(source_etablissement, "departement"),
     }
     return formatted_etablissement
 

--- a/aio/aio-proxy/aio_proxy/response/formatters/etablissements.py
+++ b/aio/aio-proxy/aio_proxy/response/formatters/etablissements.py
@@ -1,3 +1,4 @@
+from aio_proxy.response.formatters.enseignes import format_enseignes
 from aio_proxy.response.helpers import get_value
 
 
@@ -17,12 +18,7 @@ def format_etablissement(source_etablissement):
         "distribution_speciale": get_value(
             source_etablissement, "distribution_speciale"
         ),
-        "enseigne_1": get_value(source_etablissement, "enseigne_1"),
-        "enseigne_2": get_value(source_etablissement, "enseigne_2"),
-        "enseigne_3": get_value(source_etablissement, "enseigne_3"),
-        "est_source_etablissement": get_value(
-            source_etablissement, "est_source_etablissement"
-        ),
+        "est_siege": get_value(source_etablissement, "est_siege"),
         "etat_administratif": get_value(source_etablissement, "etat_administratif"),
         "geo_adresse": get_value(source_etablissement, "geo_adresse"),
         "geo_id": get_value(source_etablissement, "geo_id"),
@@ -37,6 +33,13 @@ def format_etablissement(source_etablissement):
             source_etablissement, "libelle_pays_etranger"
         ),
         "libelle_voie": get_value(source_etablissement, "libelle_voie"),
+        "liste_enseignes": format_enseignes(
+            [
+                get_value(source_etablissement, "enseigne_1"),
+                get_value(source_etablissement, "enseigne_2"),
+                get_value(source_etablissement, "enseigne_3"),
+            ]
+        ),
         "liste_finess": get_value(source_etablissement, "liste_finess"),
         "liste_idcc": get_value(source_etablissement, "liste_idcc"),
         "liste_rge": get_value(source_etablissement, "liste_rge"),
@@ -57,10 +60,35 @@ def format_etablissement(source_etablissement):
 
 
 def format_etablissements_list(etablissements=None):
+    hidden_fields = [
+        "activite_principale_registre_metier",
+        "coordonnees",
+        "cedex",
+        "code_pays_etranger",
+        "commune",
+        "complement_adresse",
+        "date_creation",
+        "date_debut_activite",
+        "departement",
+        "distribution_speciale",
+        "geo_adresse",
+        "indice_repetition",
+        "libelle_cedex",
+        "libelle_commune",
+        "libelle_commune_etranger",
+        "libelle_pays_etranger",
+        "libelle_voie",
+        "numero_voie",
+        "tranche_effectif_salarie",
+        "type_voie",
+    ]
     etablissements_formatted = []
     if etablissements:
         for etablissement in etablissements:
             etablissement_formatted = format_etablissement(etablissement)
+            # Hide certain fields from response
+            for field in hidden_fields:
+                del etablissement_formatted[field]
             etablissements_formatted.append(etablissement_formatted)
     return etablissements_formatted
 

--- a/aio/aio-proxy/aio_proxy/response/formatters/etablissements.py
+++ b/aio/aio-proxy/aio_proxy/response/formatters/etablissements.py
@@ -21,6 +21,13 @@ def format_etablissement(source_etablissement):
         "distribution_speciale": get_value(
             source_etablissement, "distribution_speciale"
         ),
+        "enseignes": format_enseignes(
+            [
+                get_value(source_etablissement, "enseigne_1"),
+                get_value(source_etablissement, "enseigne_2"),
+                get_value(source_etablissement, "enseigne_3"),
+            ]
+        ),
         "est_siege": get_value(source_etablissement, "est_siege"),
         "etat_administratif": get_value(source_etablissement, "etat_administratif"),
         "geo_adresse": get_value(source_etablissement, "geo_adresse"),
@@ -36,13 +43,6 @@ def format_etablissement(source_etablissement):
             source_etablissement, "libelle_pays_etranger"
         ),
         "libelle_voie": get_value(source_etablissement, "libelle_voie"),
-        "liste_enseignes": format_enseignes(
-            [
-                get_value(source_etablissement, "enseigne_1"),
-                get_value(source_etablissement, "enseigne_2"),
-                get_value(source_etablissement, "enseigne_3"),
-            ]
-        ),
         "liste_finess": get_value(source_etablissement, "liste_finess"),
         "liste_idcc": get_value(source_etablissement, "liste_idcc"),
         "liste_rge": get_value(source_etablissement, "liste_rge"),


### PR DESCRIPTION
closes #144 
related to #115 
Hide some fields in returned `établissements` object like detailed address fields, dates etc to make the response more compact and concise.