### PR TITLE
feat: group search results by siren

### DIFF
--- a/aio/aio-proxy/aio_proxy/search/execute_search.py
+++ b/aio/aio-proxy/aio_proxy/search/execute_search.py
@@ -10,6 +10,9 @@ def sort_and_execute_search(
 ) -> Tuple:
     search = search.extra(track_scores=True)
     search = search.extra(explain=True)
+    # Collapse is used to aggregate the results by siren. It is the consequence of
+    # separating large documents into smaller ones
+    search = search.update_from_dict({'collapse': {'field': 'siren'}})
     # Sorting is very heavy on performance if there is no
     # search terms (only filters). As there is no search terms, we can
     # exclude this sorting because score is the same for all results

--- a/aio/aio-proxy/aio_proxy/search/execute_search.py
+++ b/aio/aio-proxy/aio_proxy/search/execute_search.py
@@ -12,7 +12,7 @@ def sort_and_execute_search(
     search = search.extra(explain=True)
     # Collapse is used to aggregate the results by siren. It is the consequence of
     # separating large documents into smaller ones
-    search = search.update_from_dict({'collapse': {'field': 'siren'}})
+    search = search.update_from_dict({"collapse": {"field": "siren"}})
     # Sorting is very heavy on performance if there is no
     # search terms (only filters). As there is no search terms, we can
     # exclude this sorting because score is the same for all results

--- a/aio/aio-proxy/aio_proxy/search/queries/text.py
+++ b/aio/aio-proxy/aio_proxy/search/queries/text.py
@@ -170,7 +170,9 @@ def build_text_query(terms: str):
                                         ],
                                     }
                                 },
-                                "inner_hits": {},
+                                "inner_hits": {
+                                    "size": 10,
+                                },
                             }
                         },
                         "field_value_factor": etablissements_ouverts_multiplier,


### PR DESCRIPTION
closes #148 
Use `collapse` option in Elasticsearch to group results, containing the same `unité légale` with different établissements, by `siren`.

Also, awe increase the number of inner hits returned from the default 3 to 10.