### PR TITLE
Trier par `nombre établissements ouverts` quand uniquement des filtres sont utilisés

### DIFF
--- a/aio/aio-proxy/aio_proxy/search/execute_search.py
+++ b/aio/aio-proxy/aio_proxy/search/execute_search.py
@@ -22,6 +22,7 @@ def sort_and_execute_search(
             {"_score": {"order": "desc"}},
             {"etat_administratif_unite_legale": {"order": "asc"}},
         )
+    # If only filters are used, use nombre établissements ouverts to sort the results
     else:
         search = search.sort(
             {"nombre_etablissements_ouverts": {"order": "desc"}},

--- a/aio/aio-proxy/aio_proxy/search/execute_search.py
+++ b/aio/aio-proxy/aio_proxy/search/execute_search.py
@@ -22,6 +22,10 @@ def sort_and_execute_search(
             {"_score": {"order": "desc"}},
             {"etat_administratif_unite_legale": {"order": "asc"}},
         )
+    else:
+        search = search.sort(
+            {"nombre_etablissements_ouverts": {"order": "desc"}},
+        )
     search.aggs.metric("by_cluster", "cardinality", field="siren")
     search = search[offset : (offset + page_size)]
     search_results = search.execute()

--- a/aio/aio-proxy/aio_proxy/search/filters/nested_etablissements_filters.py
+++ b/aio/aio-proxy/aio_proxy/search/filters/nested_etablissements_filters.py
@@ -81,7 +81,10 @@ def build_nested_etablissements_filters_query(with_inner_hits=False, **params):
         filters_query["nested"]["query"]["bool"]["must"] = must_filters
 
     if with_inner_hits:
-        filters_query["nested"]["inner_hits"] = {}
+        filters_query["nested"]["inner_hits"] = {
+            "size": 10,
+            "sort": {"etablissements.etat_administratif": {"order": "asc"}},
+        }
 
     return filters_query
 

--- a/aio/aio-proxy/aio_proxy/search/queries/text.py
+++ b/aio/aio-proxy/aio_proxy/search/queries/text.py
@@ -172,8 +172,11 @@ def build_text_query(terms: str):
                                 },
                                 "inner_hits": {
                                     "size": 10,
-                                    "sort": {"etablissements.etat_administratif": {
-                                        "order": "asc"}},
+                                    "sort": {
+                                        "etablissements.etat_administratif": {
+                                            "order": "asc"
+                                        }
+                                    },
                                 },
                             }
                         },

--- a/aio/aio-proxy/aio_proxy/search/queries/text.py
+++ b/aio/aio-proxy/aio_proxy/search/queries/text.py
@@ -172,6 +172,8 @@ def build_text_query(terms: str):
                                 },
                                 "inner_hits": {
                                     "size": 10,
+                                    "sort": {"etablissements.etat_administratif": {
+                                        "order": "asc"}},
                                 },
                             }
                         },


### PR DESCRIPTION
When using filters, no specific sorting method was used. Hence, the results appeared to be random and often the top results are inactive `unites légales`.
To fix this, we sort on `nombre établissements ouverts` when only filters are used (without text search).
Also, this PR increases the size of `matching établissements` (inner hits) from the default `3` to `10`, similar to what was done with text search.