### PR TITLE
Fix case sensitive terms match

### DIFF
--- a/aio/aio-proxy/aio_proxy/parsers/string_parser.py
+++ b/aio/aio-proxy/aio_proxy/parsers/string_parser.py
@@ -21,5 +21,5 @@ def parse_parameter(request, param: str, default_value=None):
     param = request.rel_url.query.get(param, default_value)
     if param is None:
         return None
-    param = param.replace("-", " ")
+    param = param.replace("-", " ").lower()
     return param

--- a/aio/aio-proxy/aio_proxy/parsers/terms.py
+++ b/aio/aio-proxy/aio_proxy/parsers/terms.py
@@ -11,6 +11,8 @@ def parse_and_validate_terms(request, default_value=None):
         ValueError: otherwise.
     """
     terms = request.rel_url.query.get("q", default_value)
+    if terms:
+        return terms.lower()
     return terms
 
 


### PR DESCRIPTION
When searching for terms using upper case terms and when searching using the same terms but in lower case, the results are different. Fix the terms parsing by use lower case by default.