### PR TITLE
Add `commune` to multi-match search

### DIFF
--- a/aio/aio-proxy/aio_proxy/doc/open-api.yml
+++ b/aio/aio-proxy/aio_proxy/doc/open-api.yml
@@ -447,12 +447,13 @@ paths:
                               type: string
                               example: >-
                                 DIRECTION GENERALE DE LA POSTE 9 RUE DU COLONEL
-                                PIERRE AVIA 75115 PARIS 15
+                                PIERRE AVIA 75015 PARIS 15
                               description: >-
                                 Champs construit depuis les champs d'adresse de la 
                                 base SIRENE : *complement adresse + numéro voie + 
                                 indice repetition + type voie + libelle voie + 
-                                distribution spéciale + (commune + libelle commune | 
+                                distribution spéciale + (code postal + libelle 
+                                commune | 
                                 cedex + libelle cedex) + libelle commune étranger + 
                                 libelle pays étranger*
                             cedex:
@@ -735,14 +736,14 @@ paths:
                               adresse:
                                 type: string
                                 example: >-
-                                  19 RUE DE LA POSTE 31150 CORNEBARRIEU
+                                  19 RUE DE LA POSTE 31700 CORNEBARRIEU
                                 description: >-
                                   Champs construit depuis les champs d'adresse de la 
                                   base SIRENE : *complement adresse + numéro voie + 
                                   indice repetition + type voie + libelle voie + 
-                                  distribution spéciale + (commune + libelle commune | 
-                                  cedex + libelle cedex) + libelle commune étranger + 
-                                  libelle pays étranger*
+                                  distribution spéciale + (code postal + libelle 
+                                  commune | cedex + libelle cedex) + libelle commune 
+                                  étranger + libelle pays étranger*
                               code_postal:
                                 type: string
                                 nullable: true
@@ -1093,12 +1094,12 @@ paths:
                               type: string
                               example: >-
                                 DIRECTION GENERALE DE LA POSTE 9 RUE DU COLONEL
-                                PIERRE AVIA 75115 PARIS 15
+                                PIERRE AVIA 75015 PARIS 15
                               description: >-
                                 Champs construit depuis les champs d'adresse de la 
                                 base SIRENE : *complement adresse + numéro voie + 
                                 indice repetition + type voie + libelle voie + 
-                                distribution spéciale + (commune + libelle commune | 
+                                distribution spéciale + (code postal + libelle commune | 
                                 cedex + libelle cedex) + libelle commune étranger + 
                                 libelle pays étranger*
                             cedex:
@@ -1382,14 +1383,14 @@ paths:
                               adresse:
                                 type: string
                                 example: >-
-                                  19 RUE DE LA POSTE 31150 CORNEBARRIEU
+                                  19 RUE DE LA POSTE 31700 CORNEBARRIEU
                                 description: >-
                                   Champs construit depuis les champs d'adresse de la 
                                   base SIRENE : *complement adresse + numéro voie + 
                                   indice repetition + type voie + libelle voie + 
-                                  distribution spéciale + (commune + libelle commune | 
-                                  cedex + libelle cedex) + libelle commune étranger + 
-                                  libelle pays étranger*
+                                  distribution spéciale + (code postal + libelle 
+                                  commune | cedex + libelle cedex) + libelle commune 
+                                  étranger + libelle pays étranger*
                               code_postal:
                                 type: string
                                 nullable: true

--- a/aio/aio-proxy/aio_proxy/doc/open-api.yml
+++ b/aio/aio-proxy/aio_proxy/doc/open-api.yml
@@ -744,15 +744,13 @@ paths:
                                   distribution spéciale + (code postal + libelle 
                                   commune | cedex + libelle cedex) + libelle commune 
                                   étranger + libelle pays étranger*
-                              code_postal:
+                              commune:
                                 type: string
-                                nullable: true
-                                pattern: >-
-                                  ^((0[1-9])|([1-8][0-9])|(9[0-8])|(2A)|(2B))[0-9]{3}$
-                                example: "31700"
+                                example: "31150"
                                 description: >-
-                                  Le code postal de l'adresse de l'établissement 
-                                  (source : base SIRENE).
+                                  Le code géographique de la commune de localisation de
+                                  l'établissement, hors adresse à l'étranger (source : 
+                                  base SIRENE).
                               est_siege:
                                 type: boolean
                                 example: false
@@ -1391,15 +1389,13 @@ paths:
                                   distribution spéciale + (code postal + libelle 
                                   commune | cedex + libelle cedex) + libelle commune 
                                   étranger + libelle pays étranger*
-                              code_postal:
+                              commune:
                                 type: string
-                                nullable: true
-                                pattern: >-
-                                  ^((0[1-9])|([1-8][0-9])|(9[0-8])|(2A)|(2B))[0-9]{3}$
-                                example: "31700"
+                                example: "31150"
                                 description: >-
-                                  Le code postal de l'adresse de l'établissement 
-                                  (source : base SIRENE).
+                                  Le code géographique de la commune de localisation de
+                                  l'établissement, hors adresse à l'étranger (source : 
+                                  base SIRENE).
                               est_siege:
                                 type: boolean
                                 example: false

--- a/aio/aio-proxy/aio_proxy/response/formatters/etablissements.py
+++ b/aio/aio-proxy/aio_proxy/response/formatters/etablissements.py
@@ -65,7 +65,7 @@ def format_etablissements_list(etablissements=None):
         "coordonnees",
         "cedex",
         "code_pays_etranger",
-        "commune",
+        "code_postal",
         "complement_adresse",
         "date_creation",
         "date_debut_activite",

--- a/aio/aio-proxy/aio_proxy/search/queries/text.py
+++ b/aio/aio-proxy/aio_proxy/search/queries/text.py
@@ -157,6 +157,7 @@ def build_text_query(terms: str, matching_size: int):
                                                         "etablissements.enseigne_3",
                                                         "etablissements.nom_commercial",
                                                         "etablissements.adresse",
+                                                        "etablissements.commune",
                                                         "etablissements.concat_"
                                                         "enseigne_adresse_siren_siret",
                                                     ],


### PR DESCRIPTION
The address now used `code_postal` instead of `code_commune`. We should however be able to find the `établissement` using `code_commune` as well. Hence, we add the field to the multi-match search.