### PR TITLE
fix: cover nil per page

### DIFF
--- a/aio/aio-proxy/aio_proxy/parsers/per_page.py
+++ b/aio/aio-proxy/aio_proxy/parsers/per_page.py
@@ -20,6 +20,7 @@ def parse_and_validate_per_page(request) -> int:
     per_page = int(request.rel_url.query.get("per_page", 10))  # default 10
     # Limit number of results per page for performance reasons
     max_per_page = 25
-    if per_page > max_per_page:
+    min_per_page = 1
+    if per_page > max_per_page or per_page < min_per_page:
         raise ValueError
     return per_page

--- a/aio/aio-proxy/aio_proxy/tests/e2e_tests/test_api.py
+++ b/aio/aio-proxy/aio_proxy/tests/e2e_tests/test_api.py
@@ -141,3 +141,12 @@ def test_est_service_public():
     assert response_filters_only.status_code == ok_status_code
     assert total_results > min_total_results_service_public
     assert response_filters_with_text.status_code == ok_status_code
+
+
+def test_min_per_page():
+    """
+    test if giving a per_page smaller than 0, return a value error
+    """
+    path = "search?q=ganymede&per_page=0"
+    response = session.get(url=base_url + path)
+    assert response.status_code == client_error_status_code


### PR DESCRIPTION
A call with `per_page=0` caused an internal server error report.