### PR TITLE
fix: return `None` when `nom_complet` is empty

### DIFF
--- a/aio/aio-proxy/aio_proxy/response/helpers.py
+++ b/aio/aio-proxy/aio_proxy/response/helpers.py
@@ -49,5 +49,7 @@ def format_nom_complet(
         nom_complet = f"{nom_complet} ({all_denomination_usuelle.strip()})"
     if sigle:
         nom_complet = f"{nom_complet} ({sigle})"
-
-    return nom_complet.upper()
+    if nom_complet:
+        return nom_complet.upper()
+    # if nom_complet is null
+    return None

--- a/aio/aio-proxy/aio_proxy/tests/e2e_tests/test_api.py
+++ b/aio/aio-proxy/aio_proxy/tests/e2e_tests/test_api.py
@@ -150,3 +150,12 @@ def test_min_per_page():
     path = "search?q=ganymede&per_page=0"
     response = session.get(url=base_url + path)
     assert response.status_code == client_error_status_code
+
+
+def test_siren_search():
+    """
+    test if valid `siren` search returns results
+    """
+    path = "search?q=130025265"
+    response = session.get(url=base_url + path)
+    assert response.status_code == ok_status_code


### PR DESCRIPTION
Some siren have empty `nom_complet` (example: `337698138` https://annuaire-entreprises.data.gouv.fr/entreprise/337698138?redirected=1), it causes an internal server error because we did not cover that possibility.