### PR TITLE
feat: add ban parameters function to parameter parsing

### DIFF
--- a/aio/aio-proxy/aio_proxy/parsers/ban_params.py
+++ b/aio/aio-proxy/aio_proxy/parsers/ban_params.py
@@ -1,0 +1,4 @@
+def ban_params(request, param):
+    banned_param = request.rel_url.query.get(param)
+    if banned_param:
+        raise ValueError(f"Le paramètre {param} n'existe pas.")

--- a/aio/aio-proxy/aio_proxy/search/parameters.py
+++ b/aio/aio-proxy/aio_proxy/search/parameters.py
@@ -1,4 +1,5 @@
 from aio_proxy.parsers.activite_principale import validate_activite_principale
+from aio_proxy.parsers.ban_params import ban_params
 from aio_proxy.parsers.bool_fields import validate_bool_field
 from aio_proxy.parsers.code_commune import validate_code_commune
 from aio_proxy.parsers.code_postal import validate_code_postal
@@ -51,6 +52,7 @@ def extract_text_parameters(
     Raises:
         HTTPBadRequest: if ValueError or KeyError raised.
     """
+    ban_params(request, "localisation")
     page = parse_and_validate_page(request)
     per_page = parse_and_validate_per_page(request)
     terms = parse_and_validate_terms(request)

--- a/aio/aio-proxy/aio_proxy/tests/e2e_tests/test_api.py
+++ b/aio/aio-proxy/aio_proxy/tests/e2e_tests/test_api.py
@@ -159,3 +159,12 @@ def test_siren_search():
     path = "search?q=130025265"
     response = session.get(url=base_url + path)
     assert response.status_code == ok_status_code
+
+
+def test_banned_param():
+    """
+    test if banned param returns a 400 status code.
+    """
+    path = "search?localisation=45000"
+    response = session.get(url=base_url + path)
+    assert response.status_code == client_error_status_code


### PR DESCRIPTION
Many calls have been made to the API using a `localisation` parameter (which does not exist) with some filters. These calls are very heavy and have caused multiple timeouts today.
This PR send a `400` response when making a request with a `localisation` param.