### PR TITLE
Downgrade python version from 3.11 to 3.10

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        python-version: [3.11.2]
+        python-version: [3.10.8]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.11.2]
+        python-version: [3.10.8]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.11.2]
+        python-version: [3.10.8]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/aio/Dockerfile
+++ b/aio/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.10.8
 
 COPY ./aio-proxy /app
 
@@ -9,4 +9,4 @@ RUN pip install --no-cache-dir -r requirements.pip
 
 EXPOSE 4500
 
-CMD [ "make", "run" ] 
+CMD [ "make", "run" ]

--- a/aio/aio-proxy/requirements.pip
+++ b/aio/aio-proxy/requirements.pip
@@ -5,6 +5,6 @@ elasticsearch_dsl==7.4.0
 requests==2.27.1
 sentry-sdk==1.5.8
 python-dotenv==0.20.0
-pytest
-aiohttp-swagger3
-elastic-apm
+pytest==7.2.1
+aiohttp-swagger3==0.5.3
+elastic-apm==6.14.0


### PR DESCRIPTION
Conflicts with aiohttp and redis when using python `3.11.2`, downgrading for now...