### PR TITLE
fix: add page and page size to cache key

### DIFF
--- a/aio/aio-proxy/aio_proxy/search/execute_search.py
+++ b/aio/aio-proxy/aio_proxy/search/execute_search.py
@@ -99,8 +99,11 @@ def sort_and_execute_search(
             include_etablissements,
         )
 
+    # To make sure the page and page size are part of the cache key
+    cache_key = search[offset : (offset + page_size)]
+
     search_response = cache_strategy(
-        search,
+        cache_key,
         get_search_response,
         should_cache_search_response,
         TIME_TO_LIVE,


### PR DESCRIPTION
When elastic search offset and page size was moved to the execute search function (to avoid unnecessary aggregation by siren), it was no longer part of the `search` object which we use as cache key.
This PR adds the offset' and page size to the search object before caching it.