### PR TITLE
Add bilan_financier object in API

### DIFF
--- a/aio/aio-proxy/aio_proxy/doc/open-api.yml
+++ b/aio/aio-proxy/aio_proxy/doc/open-api.yml
@@ -269,6 +269,49 @@ paths:
             enum:
               - true
               - false
+        - name: bilan_renseigne
+          in: query
+          description: >-
+            Uniquement les entreprises dont le bilan est renseigné
+            (Source : INPI)
+          required: false
+          schema:
+            type: boolean
+            enum:
+              - true
+              - false          
+        - name: ca_min
+          in: query
+          description: >-
+            Valeur minimale du chiffre d'affaire de l'entreprise
+          example: "100000"
+          required: false
+          schema:
+            type: integer
+        - name: ca_max
+          in: query
+          description: >-
+            Valeur maximale du chiffre d'affaire de l'entreprise
+          example: "100000"
+          required: false
+          schema:
+            type: integer
+        - name: resultat_net_min
+          in: query
+          description: >-
+            Valeur minimale du résultat net de l'entreprise
+          example: "100000"
+          required: false
+          schema:
+            type: integer
+        - name: resultat_net_max
+          in: query
+          description: >-
+            Valeur maximale du résultat net de l'entreprise
+          example: "100000"
+          required: false
+          schema:
+            type: integer
         - name: etat_administratif
           in: query
           description: >-
@@ -914,9 +957,33 @@ paths:
                             oneOf:
                               - $ref: '#/components/schemas/dirigeant_pp'
                               - $ref: '#/components/schemas/dirigeant_pm'
+                        bilan_financier:
+                          type: object
+                          properties:
+                            ca:
+                              type: integer
+                              example: 100000
+                              description: >-
+                                Chiffre d'affaire de l'entreprise
+                            resultat_net:
+                              type: integer
+                              example: 100000
+                              description: >-
+                                Résultat net de l'entreprise
+                            date_cloture_exercice:
+                              type: string
+                              example: "2021-12-31"
+                              description: >-
+                                Date de cloture de l'exercice du bilan
                         complements:
                           type: object
                           properties:
+                            bilan_renseigne:
+                              type: boolean
+                              description: >-
+                                Entreprise ayant un bilan renseigne
+                                (source : INPI)
+                              example: true
                             collectivite_territoriale:
                               type: object
                               $ref: >-
@@ -1616,9 +1683,33 @@ paths:
                             oneOf:
                               - $ref: '#/components/schemas/dirigeant_pp'
                               - $ref: '#/components/schemas/dirigeant_pm'
+                        bilan_financier:
+                          type: object
+                          properties:
+                            ca:
+                              type: integer
+                              example: 100000
+                              description: >-
+                                Chiffre d'affaire de l'entreprise
+                            resultat_net:
+                              type: integer
+                              example: 100000
+                              description: >-
+                                Résultat net de l'entreprise
+                            date_cloture_exercice:
+                              type: string
+                              example: "2021-12-31"
+                              description: >-
+                                Date de cloture de l'exercice du bilan
                         complements:
                           type: object
                           properties:
+                            bilan_renseigne:
+                              type: boolean
+                              description: >-
+                                Entreprise ayant un bilan renseigne
+                                (source : INPI)
+                              example: true
                             collectivite_territoriale:
                               type: object
                               $ref: >-

--- a/aio/aio-proxy/aio_proxy/parsers/int_parser.py
+++ b/aio/aio-proxy/aio_proxy/parsers/int_parser.py
@@ -1,5 +1,3 @@
-from datetime import date
-
 from aio_proxy.decorators.value_exception import value_exception_handler
 
 
@@ -17,6 +15,6 @@ def parse_and_validate_int(request, param: str, default_value=None):
         param otherwise.
     """
     int_val = request.rel_url.query.get(param, default_value)
-    if int_val and int_val.isnumeric():
-        return int(int_val)
-    return None
+    if int_val is None:
+        return None
+    return int(int_val)

--- a/aio/aio-proxy/aio_proxy/parsers/int_parser.py
+++ b/aio/aio-proxy/aio_proxy/parsers/int_parser.py
@@ -1,0 +1,22 @@
+from datetime import date
+
+from aio_proxy.decorators.value_exception import value_exception_handler
+
+
+@value_exception_handler(error="Veuillez indiquer un entier. Exemple : 100000")
+def parse_and_validate_int(request, param: str, default_value=None):
+    """Extract int param from request.
+
+    Args:
+        request: HTTP request
+        param (str): parameter to extract from request
+        default_value:
+
+    Returns:
+        None if None.
+        param otherwise.
+    """
+    int_val = request.rel_url.query.get(param, default_value)
+    if int_val and int_val.isnumeric():
+        return int(int_val)
+    return None

--- a/aio/aio-proxy/aio_proxy/response/format_search_results.py
+++ b/aio/aio-proxy/aio_proxy/response/format_search_results.py
@@ -4,6 +4,7 @@ from aio_proxy.response.formatters.collectivite_territoriale import (
 )
 from aio_proxy.response.formatters.dirigeants import format_dirigeants
 from aio_proxy.response.formatters.ess import format_ess
+from aio_proxy.response.formatters.bilan_financier import format_bilan
 from aio_proxy.response.formatters.etablissements import (
     format_etablissements_list,
     format_siege,
@@ -51,7 +52,9 @@ def format_search_results(results, include_etablissements=False):
             "matching_etablissements": format_etablissements_list(
                 get_field("matching_etablissements")
             ),
+            "bilan_financier": format_bilan(get_field("bilan_financier")),
             "complements": {
+                "bilan_renseigne": format_bool_field(get_field("egapro_renseignee")),
                 "collectivite_territoriale": format_collectivite_territoriale(
                     get_field("colter_code"),
                     get_field("colter_code_insee"),

--- a/aio/aio-proxy/aio_proxy/response/format_search_results.py
+++ b/aio/aio-proxy/aio_proxy/response/format_search_results.py
@@ -54,7 +54,7 @@ def format_search_results(results, include_etablissements=False):
             ),
             "bilan_financier": format_bilan(get_field("bilan_financier")),
             "complements": {
-                "bilan_renseigne": format_bool_field(get_field("egapro_renseignee")),
+                "bilan_renseigne": format_bool_field(get_field("bilan_financier")),
                 "collectivite_territoriale": format_collectivite_territoriale(
                     get_field("colter_code"),
                     get_field("colter_code_insee"),

--- a/aio/aio-proxy/aio_proxy/response/format_search_results.py
+++ b/aio/aio-proxy/aio_proxy/response/format_search_results.py
@@ -1,10 +1,10 @@
+from aio_proxy.response.formatters.bilan_financier import format_bilan
 from aio_proxy.response.formatters.bool import format_bool_field
 from aio_proxy.response.formatters.collectivite_territoriale import (
     format_collectivite_territoriale,
 )
 from aio_proxy.response.formatters.dirigeants import format_dirigeants
 from aio_proxy.response.formatters.ess import format_ess
-from aio_proxy.response.formatters.bilan_financier import format_bilan
 from aio_proxy.response.formatters.etablissements import (
     format_etablissements_list,
     format_siege,

--- a/aio/aio-proxy/aio_proxy/response/formatters/bilan_financier.py
+++ b/aio/aio-proxy/aio_proxy/response/formatters/bilan_financier.py
@@ -1,0 +1,12 @@
+from aio_proxy.response.helpers import get_value
+
+
+def format_bilan(source_bilan):
+    if source_bilan:
+        formatted_bilan = {
+            "ca": get_value(source_bilan, "ca"),
+            "resultat_net": get_value(source_bilan, "resultat_net"),
+            "date_cloture_exercice": get_value(source_bilan, "date_cloture_exercice"),
+        }
+        return formatted_bilan
+    return {}

--- a/aio/aio-proxy/aio_proxy/search/filters/boolean.py
+++ b/aio/aio-proxy/aio_proxy/search/filters/boolean.py
@@ -31,3 +31,47 @@ def filter_search_by_bool_fields_unite_legale(
                     ],
                 )
     return search
+
+
+def filter_search_by_bool_nested_fields_unite_legale(
+    search, filters_to_include: list, **params
+):
+    for param_name, param_value in params.items():
+        should_apply_bool_filter = (
+            param_value is not None and param_name in filters_to_include
+        )
+        if should_apply_bool_filter:
+            # Check if bool filter value is True or False
+            if param_value:
+                search = search.filter(
+                    "bool",
+                    must=[
+                        Q(
+                            "nested",
+                            path="bilan_financier",
+                            query=Q(
+                                "exists",
+                                field=get_elasticsearch_field_name(
+                                    param_name, search_unite_legale=True
+                                ),
+                            ),
+                        )
+                    ],
+                )
+            else:
+                search = search.filter(
+                    "bool",
+                    must_not=[
+                        Q(
+                            "nested",
+                            path="bilan_financier",
+                            query=Q(
+                                "exists",
+                                field=get_elasticsearch_field_name(
+                                    param_name, search_unite_legale=True
+                                ),
+                            ),
+                        )
+                    ],
+                )
+    return search

--- a/aio/aio-proxy/aio_proxy/search/filters/boolean.py
+++ b/aio/aio-proxy/aio_proxy/search/filters/boolean.py
@@ -34,7 +34,7 @@ def filter_search_by_bool_fields_unite_legale(
 
 
 def filter_search_by_bool_nested_fields_unite_legale(
-    search, filters_to_include: list, **params
+    search, filters_to_include: list, path, **params
 ):
     for param_name, param_value in params.items():
         should_apply_bool_filter = (
@@ -48,7 +48,7 @@ def filter_search_by_bool_nested_fields_unite_legale(
                     must=[
                         Q(
                             "nested",
-                            path="bilan_financier",
+                            path=path,
                             query=Q(
                                 "exists",
                                 field=get_elasticsearch_field_name(
@@ -64,7 +64,7 @@ def filter_search_by_bool_nested_fields_unite_legale(
                     must_not=[
                         Q(
                             "nested",
-                            path="bilan_financier",
+                            path=path,
                             query=Q(
                                 "exists",
                                 field=get_elasticsearch_field_name(

--- a/aio/aio-proxy/aio_proxy/search/helpers/bilan_filters_used.py
+++ b/aio/aio-proxy/aio_proxy/search/helpers/bilan_filters_used.py
@@ -1,0 +1,14 @@
+def is_any_bilan_filter_used(**params) -> bool:
+    bilan_filters = [
+        "ca_min",
+        "ca_max",
+        "resultat_net_min",
+        "resultat_net_max",
+    ]
+    for param_name, param_value in params.items():
+        print(param_name, param_value)
+        if (
+            param_value == 0 or param_value is not None
+        ) and param_name in bilan_filters:
+            return True
+    return False

--- a/aio/aio-proxy/aio_proxy/search/helpers/bilan_filters_used.py
+++ b/aio/aio-proxy/aio_proxy/search/helpers/bilan_filters_used.py
@@ -6,9 +6,6 @@ def is_any_bilan_filter_used(**params) -> bool:
         "resultat_net_max",
     ]
     for param_name, param_value in params.items():
-        print(param_name, param_value)
-        if (
-            param_value == 0 or param_value is not None
-        ) and param_name in bilan_filters:
+        if param_value is not None and param_name in bilan_filters:
             return True
     return False

--- a/aio/aio-proxy/aio_proxy/search/helpers/elastic_fields.py
+++ b/aio/aio-proxy/aio_proxy/search/helpers/elastic_fields.py
@@ -9,6 +9,11 @@ def get_elasticsearch_field_name(param_name: str, search_unite_legale=False) -> 
     # "liste_rge" es field for "est_rge" filter).
     if search_unite_legale:
         corresponding_es_field = {
+            "bilan_renseigne": "bilan_financier.ca",
+            "ca_min": "bilan_financier.ca",
+            "ca_max": "bilan_financier.ca",
+            "resultat_net_min": "bilan_financier.resultat_net",
+            "resultat_net_max": "bilan_financier.resultat_net",
             "code_collectivite_territoriale": "colter_code",
             "est_association": "identifiant_association_unite_legale",
             "est_collectivite_territoriale": "colter_code",

--- a/aio/aio-proxy/aio_proxy/search/parameters.py
+++ b/aio/aio-proxy/aio_proxy/search/parameters.py
@@ -13,6 +13,7 @@ from aio_proxy.parsers.empty_params import check_empty_params
 from aio_proxy.parsers.ess import match_ess_bool_to_value
 from aio_proxy.parsers.etat_administratif import validate_etat_administratif
 from aio_proxy.parsers.finess import validate_id_finess
+from aio_proxy.parsers.int_parser import parse_and_validate_int
 from aio_proxy.parsers.latitude import parse_and_validate_latitude
 from aio_proxy.parsers.list_parser import str_to_list
 from aio_proxy.parsers.longitude import parse_and_validate_longitude
@@ -58,6 +59,10 @@ def extract_text_parameters(
     terms = parse_and_validate_terms(request)
     activite_principale = validate_activite_principale(
         str_to_list(clean_parameter(request, param="activite_principale"))
+    )
+    bilan_renseigne = validate_bool_field(
+        "bilan_renseigne",
+        clean_parameter(request, param="bilan_renseigne"),
     )
     code_commune = validate_code_commune(
         str_to_list(clean_parameter(request, param="code_commune"))
@@ -145,6 +150,10 @@ def extract_text_parameters(
     max_date_naiss_personne = parse_and_validate_date(
         request, param="date_naissance_personne_max"
     )
+    ca_min = parse_and_validate_int(request, param="ca_min")
+    ca_max = parse_and_validate_int(request, param="ca_max")
+    resultat_net_min = parse_and_validate_int(request, param="resultat_net_min")
+    resultat_net_max = parse_and_validate_int(request, param="resultat_net_max")
     type_personne = validate_type_personne(
         clean_parameter(request, param="type_personne")
     )
@@ -167,7 +176,12 @@ def extract_text_parameters(
     parameters = {
         "terms": terms,
         "activite_principale_unite_legale": activite_principale,
+        "bilan_renseigne": bilan_renseigne,
         "commune": code_commune,
+        "ca_min": ca_min,
+        "ca_max": ca_max,
+        "resultat_net_min": resultat_net_min,
+        "resultat_net_max": resultat_net_max,
         "code_postal": code_postal,
         "departement": departement,
         "section_activite_principale": section_activite_principale,

--- a/aio/aio-proxy/aio_proxy/search/queries/bilan.py
+++ b/aio/aio-proxy/aio_proxy/search/queries/bilan.py
@@ -1,0 +1,41 @@
+from elasticsearch_dsl import query
+from aio_proxy.search.helpers.elastic_fields import get_elasticsearch_field_name
+
+
+def search_bilan(
+    search,
+    bilan_filters_to_include,
+    **params,
+):
+    search_options = []
+    bilan_filters = []
+    for filter in bilan_filters_to_include:
+        filter_value = params.get(filter, None)
+        if filter_value:
+            if "min" in filter:
+                operator = "gte"
+            if "max" in filter:
+                operator = "lte"
+            bilan_filters.append(
+                {
+                    "range": {
+                        **{
+                            get_elasticsearch_field_name(
+                                filter, search_unite_legale=True
+                            ): {operator: filter_value}
+                        }
+                    }
+                }
+            )
+
+    if bilan_filters:
+        search_options.append(
+            query.Q(
+                "nested",
+                path="bilan_financier",
+                query=query.Bool(must=bilan_filters),
+            )
+        )
+
+    search = search.query("bool", should=search_options)
+    return search

--- a/aio/aio-proxy/aio_proxy/search/queries/bilan.py
+++ b/aio/aio-proxy/aio_proxy/search/queries/bilan.py
@@ -1,5 +1,5 @@
-from elasticsearch_dsl import query
 from aio_proxy.search.helpers.elastic_fields import get_elasticsearch_field_name
+from elasticsearch_dsl import query
 
 
 def search_bilan(

--- a/aio/aio-proxy/aio_proxy/search/queries/bilan.py
+++ b/aio/aio-proxy/aio_proxy/search/queries/bilan.py
@@ -12,7 +12,6 @@ def search_bilan(
     for filter in bilan_filters_to_include:
         filter_value = params.get(filter, None)
         if filter_value is not None:
-
             if "min" in filter:
                 operator = "gte"
             if "max" in filter:

--- a/aio/aio-proxy/aio_proxy/search/queries/bilan.py
+++ b/aio/aio-proxy/aio_proxy/search/queries/bilan.py
@@ -11,7 +11,8 @@ def search_bilan(
     bilan_filters = []
     for filter in bilan_filters_to_include:
         filter_value = params.get(filter, None)
-        if filter_value:
+        if filter_value is not None:
+
             if "min" in filter:
                 operator = "gte"
             if "max" in filter:

--- a/aio/aio-proxy/aio_proxy/search/text_search.py
+++ b/aio/aio-proxy/aio_proxy/search/text_search.py
@@ -154,7 +154,7 @@ def text_search(index, offset: int, page_size: int, **params):
             )
             search_client = search_client.query(Q(text_query))
 
-    # Search by CA
+    # Search by chiffre d'affaire or resultat net in bilan_financier
     is_bilan_bilan_used = is_any_bilan_filter_used(**params)
     if is_bilan_bilan_used:
         search_client = search_bilan(

--- a/aio/aio-proxy/aio_proxy/search/text_search.py
+++ b/aio/aio-proxy/aio_proxy/search/text_search.py
@@ -100,6 +100,7 @@ def text_search(index, offset: int, page_size: int, **params):
         filters_to_include=[
             "bilan_renseigne",
         ],
+        path="bilan_financier",
         **params,
     )
 

--- a/aio/aio-proxy/aio_proxy/search/text_search.py
+++ b/aio/aio-proxy/aio_proxy/search/text_search.py
@@ -95,6 +95,8 @@ def text_search(index, offset: int, page_size: int, **params):
         **params,
     )
 
+    # Boolean nested field filters unite_legale
+    # For now, only use for bilan_financier object
     search_client = filter_search_by_bool_nested_fields_unite_legale(
         search_client,
         filters_to_include=[

--- a/aio/aio-proxy/aio_proxy/search/text_search.py
+++ b/aio/aio-proxy/aio_proxy/search/text_search.py
@@ -1,5 +1,8 @@
 from aio_proxy.search.execute_search import sort_and_execute_search
-from aio_proxy.search.filters.boolean import filter_search_by_bool_fields_unite_legale
+from aio_proxy.search.filters.boolean import (
+    filter_search_by_bool_fields_unite_legale,
+    filter_search_by_bool_nested_fields_unite_legale,
+)
 from aio_proxy.search.filters.nested_etablissements_filters import (
     add_nested_etablissements_filters_to_text_query,
     build_nested_etablissements_filters_query,
@@ -10,11 +13,13 @@ from aio_proxy.search.filters.term_filters import (
     filter_term_list_search_unite_legale,
     filter_term_search_unite_legale,
 )
+from aio_proxy.search.helpers.bilan_filters_used import is_any_bilan_filter_used
 from aio_proxy.search.helpers.etablissements_filters_used import (
     is_any_etablissement_filter_used,
 )
 from aio_proxy.search.parsers.siren import is_siren
 from aio_proxy.search.parsers.siret import is_siret
+from aio_proxy.search.queries.bilan import search_bilan
 from aio_proxy.search.queries.person import search_person
 from aio_proxy.search.queries.text import build_text_query
 from elasticsearch_dsl import Q
@@ -90,6 +95,14 @@ def text_search(index, offset: int, page_size: int, **params):
         **params,
     )
 
+    search_client = filter_search_by_bool_nested_fields_unite_legale(
+        search_client,
+        filters_to_include=[
+            "bilan_renseigne",
+        ],
+        **params,
+    )
+
     # Check if any etablissements filters are used
     etablissement_filter_used = is_any_etablissement_filter_used(**params)
 
@@ -137,6 +150,20 @@ def text_search(index, offset: int, page_size: int, **params):
                 terms=query_terms, matching_size=params["matching_size"]
             )
             search_client = search_client.query(Q(text_query))
+
+    # Search by CA
+    is_bilan_bilan_used = is_any_bilan_filter_used(**params)
+    if is_bilan_bilan_used:
+        search_client = search_bilan(
+            search_client,
+            bilan_filters_to_include=[
+                "ca_min",
+                "ca_max",
+                "resultat_net_min",
+                "resultat_net_max",
+            ],
+            **params,
+        )
 
     # Search 'élus' only
     if params["type_personne"] == "ELU":


### PR DESCRIPTION
5 new filters : 
- `bilan_renseigne` # true or false
- `ca_min` and `ca_max` # allows to filter between range of chiffre d'affaire of a company
- `resultat_net_min` and `resultat_net_max` # allows to filter between range of resultat net of a company

New properties added in response : 
In `complements` : `bilan_renseigne` # Indicate if a bilan exist for a specific company
In payload `bilan_financier`. When fulfilled three properties : 
```
"bilan_financier": {
     "ca": 1379705,
     "resultat_net": 321178,
     "date_cloture_exercice": "2021-12-31"
},
```