### PR TITLE
Ajouter la paramètre `inclure_slug` qui est `false` par défaut

### DIFF
--- a/aio/aio-proxy/aio_proxy/doc/open-api.yml
+++ b/aio/aio-proxy/aio_proxy/doc/open-api.yml
@@ -792,13 +792,6 @@ paths:
                           type: string
                           example: "H"
                           description: Calculée à partir de l'activité principale.
-                        slug_annuaire_entreprises:
-                          type: string
-                          example: "mon-entreprise-412455469"
-                          description: >-
-                            Slug de l'unité légale calculée à partir de ses
-                            dénominations et de son siren.
-                            Utilisé par le site annuaire-entreprises
                         matching_etablissements:
                           type: array
                           items:
@@ -1506,13 +1499,6 @@ paths:
                           type: string
                           example: "H"
                           description: Calculée à partir de l'activité principale.
-                        slug_annuaire_entreprises:
-                          type: string
-                          example: "mon-entreprise-412455469"
-                          description: >-
-                            Slug de l'unité légale calculée à partir de ses
-                            dénominations et de son siren.
-                            Utilisé par le site annuaire-entreprises
                         matching_etablissements:
                           type: array
                           items:

--- a/aio/aio-proxy/aio_proxy/response/build_response.py
+++ b/aio/aio-proxy/aio_proxy/response/build_response.py
@@ -30,7 +30,10 @@ def api_response(
     results = search_results["response"]
     execution_time = search_results["execution_time"]
     include_etablissements = search_results["include_etablissements"]
-    results_formatted = format_search_results(results, include_etablissements)
+    include_slug = search_results["include_slug"]
+    results_formatted = format_search_results(
+        results, include_etablissements, include_slug
+    )
     response_formatted = format_response(
         results_formatted, total_results, page, per_page, execution_time
     )

--- a/aio/aio-proxy/aio_proxy/response/format_search_results.py
+++ b/aio/aio-proxy/aio_proxy/response/format_search_results.py
@@ -11,7 +11,7 @@ from aio_proxy.response.formatters.etablissements import (
 from aio_proxy.response.helpers import format_nom_complet, get_value, is_dev_env
 
 
-def format_search_results(results, include_etablissements=False):
+def format_search_results(results, include_etablissements=False, include_slug=False):
     """Format API response to follow a specific schema."""
     formatted_results = []
     for result in results:
@@ -85,7 +85,6 @@ def format_search_results(results, include_etablissements=False):
                     "statut_entrepreneur_spectacle",
                 ),
             },
-            "slug_annuaire_entreprises": get_field("slug"),
         }
 
         # If 'include_etablissements' param is True, return 'etablissements' object
@@ -93,6 +92,9 @@ def format_search_results(results, include_etablissements=False):
         if include_etablissements:
             etablissements = format_etablissements_list(get_field("etablissements"))
             result_formatted["etablissements"] = etablissements
+
+        if include_slug:
+            result_formatted["slug_annuaire_entreprises"] = get_field("slug")
 
         # Include score field for dev environment
         if is_dev_env():

--- a/aio/aio-proxy/aio_proxy/search/execute_search.py
+++ b/aio/aio-proxy/aio_proxy/search/execute_search.py
@@ -9,7 +9,7 @@ MAX_TOTAL_RESULTS = 10000
 
 
 def execute_and_format_search_response(
-    search, offset, page_size, include_etablissements
+    search, offset, page_size, include_etablissements, include_slug
 ):
     search_max_total_results = search
     search = search[offset : (offset + page_size)]
@@ -54,6 +54,7 @@ def execute_and_format_search_response(
         "response": response,
         "execution_time": execution_time,
         "include_etablissements": include_etablissements,
+        "include_slug": include_slug,
     }
     return search_response
 
@@ -82,6 +83,7 @@ def sort_and_execute_search(
     page_size: int,
     is_text_search: bool,
     include_etablissements: bool,
+    include_slug: bool,
 ) -> dict:
     search = search.extra(track_scores=True)
     search = search.extra(explain=True)
@@ -97,6 +99,7 @@ def sort_and_execute_search(
             offset,
             page_size,
             include_etablissements,
+            include_slug,
         )
 
     # To make sure the page and page size are part of the cache key

--- a/aio/aio-proxy/aio_proxy/search/parameters.py
+++ b/aio/aio-proxy/aio_proxy/search/parameters.py
@@ -168,6 +168,10 @@ def extract_text_parameters(
         "inclure_etablissements",
         clean_parameter(request, param="inclure_etablissements"),
     )
+    inclure_slug = validate_bool_field(
+        "inclure_slug",
+        clean_parameter(request, param="inclure_slug"),
+    )
 
     matching_size = parse_and_validate_matching_size(request)
 
@@ -205,6 +209,7 @@ def extract_text_parameters(
         "id_uai": id_uai,
         "id_rge": id_rge,
         "inclure_etablissements": inclure_etablissements,
+        "inclure_slug": inclure_slug,
         "code_collectivite_territoriale": code_collectivite_territoriale,
         "nom_personne": nom_personne,
         "prenoms_personne": prenoms_personne,

--- a/aio/aio-proxy/aio_proxy/search/text_search.py
+++ b/aio/aio-proxy/aio_proxy/search/text_search.py
@@ -30,6 +30,7 @@ def text_search(index, offset: int, page_size: int, **params):
     search_client = index.search()
 
     include_etablissements = params["inclure_etablissements"]
+    include_slug = params["inclure_slug"]
 
     # Filter by siren/siret first (if query is a `siren` or 'siret' number), and return
     # search results directly without text search.
@@ -45,9 +46,10 @@ def text_search(index, offset: int, page_size: int, **params):
             page_size=page_size,
             is_text_search=False,
             include_etablissements=include_etablissements,
+            include_slug=include_slug,
         )
 
-    # always apply this filter to prevent displaying non allowed information
+    # always apply this filter to prevent displaying private information
     search_client = search_client.filter(
         "term", **{"statut_diffusion_unite_legale": "O"}
     )
@@ -249,4 +251,5 @@ def text_search(index, offset: int, page_size: int, **params):
         page_size=page_size,
         is_text_search=is_text_search,
         include_etablissements=include_etablissements,
+        include_slug=include_slug,
     )


### PR DESCRIPTION
This param is only used by `annuaire des enterprises` and allows us to hide the `slug` field from the API payload.