### PR TITLE
Fix empty payload when bool filter equals `False`

### DIFF
--- a/aio/aio-proxy/aio_proxy/response/format_search_results.py
+++ b/aio/aio-proxy/aio_proxy/response/format_search_results.py
@@ -1,4 +1,3 @@
-from aio_proxy.response.formatters.bool import format_bool_field
 from aio_proxy.response.formatters.collectivite_territoriale import (
     format_collectivite_territoriale,
 )
@@ -72,14 +71,12 @@ def format_search_results(
                 "convention_collective_renseignee": get_field(
                     "convention_collective_renseignee"
                 ),
-                "egapro_renseignee": format_bool_field(get_field("egapro_renseignee")),
+                "egapro_renseignee": get_field("egapro_renseignee"),
                 "est_bio": get_field("est_bio"),
                 "est_entrepreneur_individuel": get_field(
                     "est_entrepreneur_individuel", default=False
                 ),
-                "est_entrepreneur_spectacle": format_bool_field(
-                    get_field("est_entrepreneur_spectacle")
-                ),
+                "est_entrepreneur_spectacle": get_field("est_entrepreneur_spectacle"),
                 "est_ess": format_ess(
                     get_field("economie_sociale_solidaire_unite_legale")
                 ),

--- a/aio/aio-proxy/aio_proxy/search/text_search.py
+++ b/aio/aio-proxy/aio_proxy/search/text_search.py
@@ -62,6 +62,7 @@ def text_search(index, offset: int, page_size: int, **params):
         filters_to_include=[
             "convention_collective_renseignee",
             "economie_sociale_solidaire_unite_legale",
+            "egapro_renseignee",
             "est_bio",
             "est_entrepreneur_individuel",
             "est_entrepreneur_spectacle",
@@ -94,7 +95,6 @@ def text_search(index, offset: int, page_size: int, **params):
     search_client = filter_search_by_bool_fields_unite_legale(
         search_client,
         filters_to_include=[
-            "egapro_renseignee",
             "est_association",
             "est_collectivite_territoriale",
         ],


### PR DESCRIPTION
`est_qualiopi=false` and `est_entrepreneur_spectacle=false`  :  return no results because the data indexed is either `True` or `None`.  The API shows the `None` as `False` (because we format the fields), however the `None` values cannot be filtered when using `False` as the bool filter 's value. 

This issue is resolved once the indexed value `None` is replaced with `False`
https://github.com/etalab/annuaire-entreprises-search-infra/pull/167

`egapro_renseignee=false`: works fine now because it was using a bool filter in the search function instead of a term filter like the other fields (happy coincidence maybe 🤷). 
However, once the aforementioned change in indexing the bool values takes place, this filter will no longer return any results. In order to fix that, the `egapro_renseignee` will be moved to the right search section (term search).

`egapro_renseignee` and `est_entrepreneur_spectacle` will no longer need to be formatted in the API payload because the `None` value issue is henceforward dealt with on the infra side.

closes #253 
depends on https://github.com/etalab/annuaire-entreprises-search-infra/pull/167