### PR TITLE
[REFACTOR] Remove `inclure_slug` and `inclure_score` parameters

### DIFF
--- a/aio/aio-proxy/aio_proxy/request/search_params_builder.py
+++ b/aio/aio-proxy/aio_proxy/request/search_params_builder.py
@@ -59,8 +59,6 @@ class SearchParamsBuilder:
             per_page=parse_and_validate_per_page(request),
             terms=parse_and_validate_terms(request),
             matching_size=parse_and_validate_matching_size(request),
-            inclure_score=parse_and_validate_bool_field(request, param="inclure_score"),
-            inclure_slug=parse_and_validate_bool_field(request, param="inclure_slug"),
             nature_juridique_unite_legale=validate_nature_juridique(
                 str_to_list(clean_parameter(request, param="nature_juridique"))
             ),
@@ -184,8 +182,6 @@ class SearchParamsBuilder:
                     clean_parameter(request, param="section_activite_principale")
                 )
             ),
-            inclure_slug=parse_and_validate_bool_field(request, param="inclure_slug"),
-            inclure_score=parse_and_validate_bool_field(request, param="inclure_score"),
             matching_size=parse_and_validate_matching_size(request),
             minimal=parse_and_validate_bool_field(request, param="minimal"),
             include=validate_selected_fields(

--- a/aio/aio-proxy/aio_proxy/request/search_params_model.py
+++ b/aio/aio-proxy/aio_proxy/request/search_params_model.py
@@ -54,3 +54,4 @@ class SearchParams:
     minimal: bool = None
     include: list = None
     include_admin: list = None
+    inclure_etablissements: bool = None

--- a/aio/aio-proxy/aio_proxy/request/search_params_model.py
+++ b/aio/aio-proxy/aio_proxy/request/search_params_model.py
@@ -47,9 +47,6 @@ class SearchParams:
     type_personne: str = None
     etat_administratif_unite_legale: str = None
     nature_juridique_unite_legale: list = None
-    inclure_etablissements: bool = None
-    inclure_slug: bool = None
-    inclure_score: bool = None
     matching_size: str = None
     lat: float = None
     lon: float = None

--- a/aio/aio-proxy/aio_proxy/response/format_search_results.py
+++ b/aio/aio-proxy/aio_proxy/response/format_search_results.py
@@ -109,17 +109,6 @@ def format_search_results(results, search_params):
             },
         }
 
-        include_slug = search_params.inclure_slug
-        include_score = search_params.inclure_score
-
-        # Slug is only included when param is True
-        if include_slug:
-            result_formatted["slug_annuaire_entreprises"] = get_field("slug")
-
-        # Score is only included when param is True
-        if include_score:
-            result_formatted["score"] = get_field("meta")["score"]
-
         # Select fields to return
         if search_params.minimal:
             select_fields_to_include(search_params.include, result_formatted)


### PR DESCRIPTION
depends on https://github.com/etalab/annuaire-entreprises-search-api/pull/281
These filters are now included in `include` parameter.