### PR TITLE
fix: convert es matching etablissement to list

### DIFF
--- a/aio/aio-proxy/aio_proxy/search/helpers/helpers.py
+++ b/aio/aio-proxy/aio_proxy/search/helpers/helpers.py
@@ -10,7 +10,7 @@ def extract_ul_and_etab_from_es_response(structure):
         structure_dict["matching_etablissements"] = []
         for matching_etablissement in matching_etablissements:
             structure_dict["matching_etablissements"].append(
-                matching_etablissement["_source"]
+                matching_etablissement["_source"].to_dict()
             )
     except Exception:
         structure_dict["matching_etablissements"] = []


### PR DESCRIPTION
`liste_idcc` and `cedex` fields returned as strings in payload in object `matching_etablissements`.
`matching_etablissements` is returned as an Elasticsearch `AttrDict` and not as a Python Dict which makes accessing attributes more tricky. We cast the object as a Python dict to avoid errors.