### PR TITLE
fix: return 400 if `int` is bigger than ES long range

### DIFF
--- a/aio/aio-proxy/aio_proxy/request/parsers/int_parser.py
+++ b/aio/aio-proxy/aio_proxy/request/parsers/int_parser.py
@@ -1,20 +1,16 @@
-from aio_proxy.decorators.value_exception import value_exception_handler
-
-
-@value_exception_handler(error="Veuillez indiquer un entier. Exemple : 100000")
 def parse_and_validate_int(request, param: str, default_value=None):
-    """Extract int param from request.
-
-    Args:
-        request: HTTP request
-        param (str): parameter to extract from request
-        default_value:
-
-    Returns:
-        None if None.
-        param otherwise.
-    """
     int_val = request.rel_url.query.get(param, default_value)
     if int_val is None:
         return None
-    return int(int_val)
+    try:
+        int_val = int(int_val)
+    except ValueError:
+        raise ValueError("Veuillez indiquer un entier. Exemple : 100000")
+
+    min_val = -9223372036854775295
+    max_val = 9223372036854775295
+
+    if min_val <= int_val <= max_val:
+        return int_val
+    else:
+        raise ValueError(f"Veuillez indiquer un entier entre {min_val} et {max_val}.")

--- a/aio/aio-proxy/aio_proxy/request/parsers/int_parser.py
+++ b/aio/aio-proxy/aio_proxy/request/parsers/int_parser.py
@@ -7,6 +7,7 @@ def parse_and_validate_int(request, param: str, default_value=None):
     except ValueError:
         raise ValueError("Veuillez indiquer un entier. Exemple : 100000")
 
+    # Elasticsearch `long` type maxes out at this range
     min_val = -9223372036854775295
     max_val = 9223372036854775295
 


### PR DESCRIPTION
API reutrn this error if int is bigger than Elasticsearch `long` type : 
`RequestError(400, 'search_phase_execution_exception', 'failed to create query: Value [[31 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30]] is out of range for a long')"`

This PR handles this error by returning a 400 with details if given number is outside expected range.