### PR TITLE
Latitude and longitude parse NaN values as floats

### DIFF
--- a/aio/aio-proxy/aio_proxy/request/parsers/latitude.py
+++ b/aio/aio-proxy/aio_proxy/request/parsers/latitude.py
@@ -12,11 +12,17 @@ def parse_and_validate_latitude(request):
         latitude(float) if valid.
 
     Raises:
-        ValueError: if latitude is not float, or outside range [-90, 90].
+        ValueError: if latitude is nan, not float, or outside range [-90, 90].
     """
     min_latitude = -90
     max_latitude = 90
-    lat = float(request.rel_url.query.get("lat"))
+    lat_str = request.rel_url.query.get("lat")
+    if lat_str == "nan":
+        raise ValueError
+    try:
+        lat = float(lat_str)
+    except ValueError:
+        raise ValueError
     if lat > max_latitude or lat < min_latitude:
         raise ValueError
     return lat

--- a/aio/aio-proxy/aio_proxy/request/parsers/longitude.py
+++ b/aio/aio-proxy/aio_proxy/request/parsers/longitude.py
@@ -16,7 +16,13 @@ def parse_and_validate_longitude(request):
     """
     min_longitude = -180
     max_longitude = 180
-    lon = float(request.rel_url.query.get("long"))
+    lon_str = request.rel_url.query.get("long")
+    if lon_str == "nan":
+        raise ValueError
+    try:
+        lon = float(lon_str)
+    except ValueError:
+        raise ValueError
     if lon > max_longitude or lon < min_longitude:
         raise ValueError
     return lon

--- a/aio/aio-proxy/aio_proxy/tests/e2e_tests/test_api.py
+++ b/aio/aio-proxy/aio_proxy/tests/e2e_tests/test_api.py
@@ -423,7 +423,5 @@ def test_near_point_nan_values(api_response_tester):
     api_response_tester.assert_api_response_code_400(path)
     response = api_response_tester.get_api_response(path)
     assert (
-        response.json()["erreur"]
-        == """Veuillez indiquer
-      une latitude entre -90° et 90°."""
+        response.json()["erreur"] == "Veuillez indiquer une latitude entre -90° et 90°."
     )

--- a/aio/aio-proxy/aio_proxy/tests/e2e_tests/test_api.py
+++ b/aio/aio-proxy/aio_proxy/tests/e2e_tests/test_api.py
@@ -413,3 +413,17 @@ def test_non_diffusibilite(api_response_tester):
     for dirigeant in response.json()["results"][0]["dirigeants"]:
         assert dirigeant["prenoms"] == "[NON-DIFFUSIBLE]"
         assert dirigeant["nom"] == "[NON-DIFFUSIBLE]"
+
+
+def test_near_point_nan_values(api_response_tester):
+    """
+    test near point endpoint with nan values
+    """
+    path = "near_point?lat=nan&long=nan"
+    api_response_tester.assert_api_response_code_400(path)
+    response = api_response_tester.get_api_response(path)
+    assert (
+        response.json()["erreur"]
+        == """Veuillez indiquer
+      une latitude entre -90° et 90°."""
+    )


### PR DESCRIPTION
Error detected in Sentry : `RequestError(400, 'x_content_parse_exception', '[1:254] [bool] failed to parse field [filter]')` when calling `near_point?lat=nan&long=nan`.

`float()` was used to validate `lat` and `long` parameters in request. 
Python has a built-in representation for NaN as a floating-point value. In Python, float("nan") will simply create a floating-point NaN value rather than raising an error. So when `nan` values are given (example `lat=nan`), they are validated without raising an error, and are given to Elasticsearch which in return raises that above-mentioned error.

This PR adds the `nan` value handling to the parsing and validation functions.