### PR TITLE
Remove `inclure etablissements` parameter

### DIFF
--- a/aio/aio-proxy/aio_proxy/request/search_params_builder.py
+++ b/aio/aio-proxy/aio_proxy/request/search_params_builder.py
@@ -39,7 +39,6 @@ from aio_proxy.request.parsers.section_activite_principale import (
     validate_section_activite_principale,
 )
 from aio_proxy.request.parsers.selected_fields import (
-    should_include_etablissements,
     validate_inclusion_fields,
     validate_selected_fields,
 )
@@ -173,9 +172,6 @@ class SearchParamsBuilder:
                 str_to_list(clean_parameter(request, param="include_admin")),
                 admin=True,
             ),
-            inclure_etablissements=should_include_etablissements(
-                str_to_list(clean_parameter(request, param="include_admin"))
-            ),
         )
         SearchParamsBuilder.check_and_validate_params(request, params)
         return params
@@ -204,9 +200,6 @@ class SearchParamsBuilder:
             include_admin=validate_selected_fields(
                 str_to_list(clean_parameter(request, param="include_admin")),
                 admin=True,
-            ),
-            inclure_etablissements=should_include_etablissements(
-                str_to_list(clean_parameter(request, param="include_admin"))
             ),
         )
         return params

--- a/aio/aio-proxy/aio_proxy/request/search_params_model.py
+++ b/aio/aio-proxy/aio_proxy/request/search_params_model.py
@@ -54,4 +54,3 @@ class SearchParams:
     minimal: bool = None
     include: list = None
     include_admin: list = None
-    inclure_etablissements: bool = None

--- a/aio/aio-proxy/aio_proxy/search/geo_search.py
+++ b/aio/aio-proxy/aio_proxy/search/geo_search.py
@@ -44,7 +44,12 @@ def build_es_search_geo_query(es_search_builder):
     )
 
     # By default, exclude etablissements list from response
-    if "ETABLISSEMENTS" not in es_search_builder.search_params.include_admin:
+    include_atablissements = (
+        es_search_builder.search_params.include_admin
+        and "ETABLISSEMENTS" in es_search_builder.search_params.include_admin
+    )
+
+    if not include_atablissements:
         es_search_builder.es_search_client = es_search_builder.es_search_client.source(
             excludes=["unite_legale.etablissements"]
         )

--- a/aio/aio-proxy/aio_proxy/search/geo_search.py
+++ b/aio/aio-proxy/aio_proxy/search/geo_search.py
@@ -44,12 +44,12 @@ def build_es_search_geo_query(es_search_builder):
     )
 
     # By default, exclude etablissements list from response
-    include_atablissements = (
+    include_etablissements = (
         es_search_builder.search_params.include_admin
         and "ETABLISSEMENTS" in es_search_builder.search_params.include_admin
     )
 
-    if not include_atablissements:
+    if not include_etablissements:
         es_search_builder.es_search_client = es_search_builder.es_search_client.source(
             excludes=["unite_legale.etablissements"]
         )

--- a/aio/aio-proxy/aio_proxy/search/geo_search.py
+++ b/aio/aio-proxy/aio_proxy/search/geo_search.py
@@ -44,7 +44,7 @@ def build_es_search_geo_query(es_search_builder):
     )
 
     # By default, exclude etablissements list from response
-    if not es_search_builder.search_params.inclure_etablissements:
+    if "ETABLISSEMENTS" not in es_search_builder.search_params.include_admin:
         es_search_builder.es_search_client = es_search_builder.es_search_client.source(
             excludes=["unite_legale.etablissements"]
         )

--- a/aio/aio-proxy/aio_proxy/search/geo_search.py
+++ b/aio/aio-proxy/aio_proxy/search/geo_search.py
@@ -1,4 +1,7 @@
 from aio_proxy.search.filters.term_filters import filter_term_list_search_unite_legale
+from aio_proxy.search.helpers.exclude_etablissements import (
+    exclude_etablissements_from_search,
+)
 from elasticsearch_dsl import Q
 
 
@@ -43,14 +46,5 @@ def build_es_search_geo_query(es_search_builder):
         Q(geo_query)
     )
 
-    # By default, exclude etablissements list from response
-    include_etablissements = (
-        es_search_builder.search_params.include_admin
-        and "ETABLISSEMENTS" in es_search_builder.search_params.include_admin
-    )
-
-    if not include_etablissements:
-        es_search_builder.es_search_client = es_search_builder.es_search_client.source(
-            excludes=["unite_legale.etablissements"]
-        )
+    exclude_etablissements_from_search(es_search_builder)
     es_search_builder.has_full_text_query = True

--- a/aio/aio-proxy/aio_proxy/search/helpers/exclude_etablissements.py
+++ b/aio/aio-proxy/aio_proxy/search/helpers/exclude_etablissements.py
@@ -1,0 +1,11 @@
+def exclude_etablissements_from_search(es_search_builder):  #
+    # By default, exclude etablissements list from response
+    include_etablissements = (
+        es_search_builder.search_params.include_admin
+        and "ETABLISSEMENTS" in es_search_builder.search_params.include_admin
+    )
+
+    if not include_etablissements:
+        es_search_builder.es_search_client = es_search_builder.es_search_client.source(
+            excludes=["etablissements"]
+        )

--- a/aio/aio-proxy/aio_proxy/search/text_search.py
+++ b/aio/aio-proxy/aio_proxy/search/text_search.py
@@ -241,7 +241,12 @@ def build_es_search_text_query(es_search_builder):
                 es_search_builder.has_full_text_query = True
 
         # By default, exclude etablissements list from response
-        if not es_search_builder.search_params.inclure_etablissements:
+        include_atablissements = (
+            es_search_builder.search_params.include_admin
+            and "ETABLISSEMENTS" in es_search_builder.search_params.include_admin
+        )
+
+        if not include_atablissements:
             es_search_builder.es_search_client = (
                 es_search_builder.es_search_client.source(excludes=["etablissements"])
             )

--- a/aio/aio-proxy/aio_proxy/search/text_search.py
+++ b/aio/aio-proxy/aio_proxy/search/text_search.py
@@ -241,12 +241,12 @@ def build_es_search_text_query(es_search_builder):
                 es_search_builder.has_full_text_query = True
 
         # By default, exclude etablissements list from response
-        include_atablissements = (
+        include_etablissements = (
             es_search_builder.search_params.include_admin
             and "ETABLISSEMENTS" in es_search_builder.search_params.include_admin
         )
 
-        if not include_atablissements:
+        if not include_etablissements:
             es_search_builder.es_search_client = (
                 es_search_builder.es_search_client.source(excludes=["etablissements"])
             )

--- a/aio/aio-proxy/aio_proxy/search/text_search.py
+++ b/aio/aio-proxy/aio_proxy/search/text_search.py
@@ -15,6 +15,9 @@ from aio_proxy.search.helpers.bilan_filters_used import is_any_bilan_filter_used
 from aio_proxy.search.helpers.etablissements_filters_used import (
     is_any_etablissement_filter_used,
 )
+from aio_proxy.search.helpers.exclude_etablissements import (
+    exclude_etablissements_from_search,
+)
 from aio_proxy.search.parsers.siren import is_siren
 from aio_proxy.search.parsers.siret import is_siret
 from aio_proxy.search.queries.bilan import search_bilan
@@ -240,13 +243,4 @@ def build_es_search_text_query(es_search_builder):
             if getattr(es_search_builder.search_params, item):
                 es_search_builder.has_full_text_query = True
 
-        # By default, exclude etablissements list from response
-        include_etablissements = (
-            es_search_builder.search_params.include_admin
-            and "ETABLISSEMENTS" in es_search_builder.search_params.include_admin
-        )
-
-        if not include_etablissements:
-            es_search_builder.es_search_client = (
-                es_search_builder.es_search_client.source(excludes=["etablissements"])
-            )
+        exclude_etablissements_from_search(es_search_builder)


### PR DESCRIPTION
Post factorosation the site has completely migrated to using new inclusion parameters. The `inclure_etablissements` param is no longer used.