### PR TITLE
fix: add 400 error message when `page*per_page` is bigger than 10 000

### DIFF
--- a/aio/aio-proxy/aio_proxy/request/helpers.py
+++ b/aio/aio-proxy/aio_proxy/request/helpers.py
@@ -8,3 +8,17 @@ def validate_date_range(min_date=None, max_date=None):
     if min_date and max_date:
         if max_date < min_date:
             raise ValueError
+
+
+MAX_RESULTS = 10000
+
+
+@value_exception_handler(
+    error="Le nombre total de résultats est restreint à 10 000. Pour garantir cela, "
+    "le produit du numéro de page (par défaut, page = 1) et du nombre de résultats "
+    "par page (par défaut, per_page = 10), c'est-à-dire `page * per_page`, ne doit pas "
+    "excéder 10 000."
+)
+def validate_results_window(page=1, per_page=10):
+    if page * per_page > MAX_RESULTS:
+        raise ValueError

--- a/aio/aio-proxy/aio_proxy/request/search_params_builder.py
+++ b/aio/aio-proxy/aio_proxy/request/search_params_builder.py
@@ -1,4 +1,4 @@
-from aio_proxy.request.helpers import validate_date_range
+from aio_proxy.request.helpers import validate_date_range, validate_results_window
 from aio_proxy.request.parsers.activite_principale import (
     validate_activite_principale,
 )
@@ -202,6 +202,7 @@ class SearchParamsBuilder:
                 admin=True,
             ),
         )
+        validate_results_window(params.page, params.per_page)
         return params
 
     @staticmethod
@@ -213,6 +214,7 @@ class SearchParamsBuilder:
             params.min_date_naiss_personne,
             params.max_date_naiss_personne,
         )
+        validate_results_window(params.page, params.per_page)
         # Prevent performance issues by refusing query terms less than 3 characters
         # unless another param is provided
         check_short_terms_and_no_param(params)


### PR DESCRIPTION
Error captured in Sentry `RequestError(400, 'search_phase_execution_exception', 'Result window is too large, from + size must be less than or equal to: [10000] but was [10025]. See the scroll api for a more efficient way to request large data sets. This limit can be set by changing the [index.max_result_window] index level setting.')`.

So far, Exception handler only captured the error when page is higher than 1000. However, when `per_page`  is bigger than 10, the 10.000 limit (number of results in ES) is reached before the page reaches 1000.

Henceforth the rule is `page*per_page` should be lower `10.000`.