### PR TITLE
[Filter SIRET] perf: filter siret on the root doc to prevent ESToParentBlockJoinQuery

### DIFF
--- a/aio/aio-proxy/aio_proxy/search/filters/siret.py
+++ b/aio/aio-proxy/aio_proxy/search/filters/siret.py
@@ -4,17 +4,7 @@ from elasticsearch_dsl import Q
 def filter_by_siret(search, siret_string):
     """Filter by 'siret' number"""
     siret_filter = {
-        "nested": {
-            "path": "unite_legale.etablissements",
-            "query": {
-                "bool": {
-                    "filter": [
-                        {"term": {"unite_legale.etablissements.siret": siret_string}}
-                    ]
-                }
-            },
-            "inner_hits": {},
-        }
+        "term": {"unite_legale.etablissements.siret": siret_string}
     }
     search = search.query(Q(siret_filter))
     return search


### PR DESCRIPTION
A déployer après cette merge request qui modifie le mapping :
https://github.com/etalab/annuaire-entreprises-search-infra/pull/203

On simplifie la recherche par SIRET et ça se traduit par un gain minime de temps d'exécution mais qui peut être significatif lorsque de nombreuses requêtes arrivent en même temps.

:warning: ce code n'a pas encore pu être testé localement