### PR TITLE
[Performance] ES requests timeout after 1s - reduce the number of retries to 1

### DIFF
--- a/aio/aio-proxy/aio_proxy/routes.py
+++ b/aio/aio-proxy/aio_proxy/routes.py
@@ -41,6 +41,7 @@ connections.create_connection(
     hosts=[ELASTIC_URL],
     http_auth=(ELASTIC_USER, ELASTIC_PASSWORD),
     retry_on_timeout=True,
+    max_retries=1
 )
 
 routes = web.RouteTableDef()

--- a/aio/aio-proxy/aio_proxy/search/es_search_runner.py
+++ b/aio/aio-proxy/aio_proxy/search/es_search_runner.py
@@ -19,7 +19,7 @@ MAX_TOTAL_RESULTS = 10000
 
 class ElasticSearchRunner:
     def __init__(self, search_params, search_type):
-        self.es_search_client = StructureMapping.search()
+        self.es_search_client = StructureMapping.search().params(request_timeout=1)
         self.search_type = search_type
         self.search_params = search_params
         self.has_full_text_query = False


### PR DESCRIPTION
Lorsqu'une request timeout après une seconde, une Exception de type ConnectionTimeout est levée.

cf: https://github.com/elastic/elasticsearch-py/blob/a6bb5f3808ef8616afde81ebc1dc53f98011a2b8/docs/guide/configuration.asciidoc#request-timeouts

Le problème c'est que la configuration définit un `retry_on_timeout` à `True`.

Cela signifie que les requests qui timeout après 1s, sont rééxécutées et risque également de timeout.
cf: https://github.com/elastic/elastic-transport-python/blob/main/elastic_transport/_transport.py#L364

Ca amplifie le problème.

Il y a deux possibilités lorsque le `request_timeout` est activé.

**_Possiblité 1 :_**
-> on désactive l'option "retry_on_timeout"

_**Possibilité 2 (choisit par cette merge request) :**_
-> on autorise un seul retry


:warning: ce code n'a pas encore été testé localement