### PR TITLE
[DATA][ESS]feat: use new field `est_ess` union of ESS France and INSEE

### DIFF
--- a/aio/aio-proxy/aio_proxy/doc/open-api.yml
+++ b/aio/aio-proxy/aio_proxy/doc/open-api.yml
@@ -1114,7 +1114,9 @@ paths:
                               example: false
                             est_ess:
                               type: boolean
-                              description: Entreprise d'économie sociale et solidaire
+                              description: >-
+                                Entreprise d'économie sociale et solidaire
+                                (source: ESS France)
                               example: false
                             est_finess:
                               type: boolean
@@ -1921,7 +1923,9 @@ paths:
                               example: false
                             est_ess:
                               type: boolean
-                              description: Entreprise d'économie sociale et solidaire
+                              description: >-
+                                Entreprise d'économie sociale et solidaire
+                                (source: ESS France)
                               example: false
                             est_finess:
                               type: boolean

--- a/aio/aio-proxy/aio_proxy/doc/open-api.yml
+++ b/aio/aio-proxy/aio_proxy/doc/open-api.yml
@@ -1116,7 +1116,7 @@ paths:
                               type: boolean
                               description: >-
                                 Entreprise d'économie sociale et solidaire
-                                (source: ESS France)
+                                (source: ESS France et INSEE)
                               example: false
                             est_finess:
                               type: boolean
@@ -1925,7 +1925,7 @@ paths:
                               type: boolean
                               description: >-
                                 Entreprise d'économie sociale et solidaire
-                                (source: ESS France)
+                                (source: ESS France et INSEE)
                               example: false
                             est_finess:
                               type: boolean

--- a/aio/aio-proxy/aio_proxy/request/search_params_builder.py
+++ b/aio/aio-proxy/aio_proxy/request/search_params_builder.py
@@ -17,7 +17,6 @@ class SearchParamsBuilder:
         "activite_principale": "activite_principale_unite_legale",
         "code_commune": "commune",
         "tranche_effectif_salarie": "tranche_effectif_salarie_unite_legale",
-        "est_ess": "economie_sociale_solidaire_unite_legale",
         "long": "lon",
     }
 

--- a/aio/aio-proxy/aio_proxy/request/search_params_model.py
+++ b/aio/aio-proxy/aio_proxy/request/search_params_model.py
@@ -40,12 +40,12 @@ class SearchParams(BaseModel):
     est_collectivite_territoriale: bool | None = None
     est_entrepreneur_spectacle: bool | None = None
     est_association: bool | None = None
+    est_ess: bool | None = None
     est_organisme_formation: bool | None = None
     est_qualiopi: bool | None = None
     est_rge: bool | None = None
     est_service_public: bool | None = None
     est_societe_mission: bool | None = None
-    economie_sociale_solidaire_unite_legale: bool | None = None
     id_convention_collective: str | None = None
     id_finess: str | None = None
     id_uai: str | None = None
@@ -189,6 +189,7 @@ class SearchParams(BaseModel):
         "est_uai",
         "est_collectivite_territoriale",
         "est_entrepreneur_spectacle",
+        "est_ess",
         "est_association",
         "est_organisme_formation",
         "est_qualiopi",
@@ -205,9 +206,7 @@ class SearchParams(BaseModel):
             raise ValueError(f"{param_name} doit prendre la valeur 'true' ou 'false' !")
         return boolean.upper() == "TRUE"
 
-    @field_validator(
-        "est_societe_mission", "economie_sociale_solidaire_unite_legale", mode="after"
-    )
+    @field_validator("est_societe_mission", mode="after")
     def convert_bool_to_insee_value(cls, boolean: bool) -> str:
         return match_bool_to_insee_value(boolean)
 

--- a/aio/aio-proxy/aio_proxy/request/search_params_model.py
+++ b/aio/aio-proxy/aio_proxy/request/search_params_model.py
@@ -197,7 +197,6 @@ class SearchParams(BaseModel):
         "est_service_public",
         "minimal",
         "est_societe_mission",
-        "economie_sociale_solidaire_unite_legale",
         mode="before",
     )
     def convert_str_to_bool(cls, boolean: str, info) -> bool:

--- a/aio/aio-proxy/aio_proxy/response/formatters/complements.py
+++ b/aio/aio-proxy/aio_proxy/response/formatters/complements.py
@@ -23,7 +23,7 @@ def format_complements(result_unite_legale):
         "est_entrepreneur_individuel", default=False
     )
     est_entrepreneur_spectacle = get_field("est_entrepreneur_spectacle")
-    est_ess = format_insee_bool(get_field("economie_sociale_solidaire_unite_legale"))
+    est_ess = get_field("est_ess")
     est_finess = get_field("est_finess")
     est_organisme_formation = get_field("est_organisme_formation")
     est_qualiopi = get_field("est_qualiopi")

--- a/aio/aio-proxy/aio_proxy/search/text_search.py
+++ b/aio/aio-proxy/aio_proxy/search/text_search.py
@@ -53,12 +53,12 @@ def build_es_search_text_query(es_search_builder):
             es_search_builder.search_params,
             filters_to_include=[
                 "convention_collective_renseignee",
-                "economie_sociale_solidaire_unite_legale",
                 "egapro_renseignee",
                 "est_association",
                 "est_bio",
                 "est_entrepreneur_individuel",
                 "est_entrepreneur_spectacle",
+                "est_ess",
                 "est_finess",
                 "est_organisme_formation",
                 "est_qualiopi",


### PR DESCRIPTION
depends on #https://github.com/etalab/annuaire-entreprises-search-infra/pull/216
closes #270 
**⚠️ TBD**
Are we expected to include the `economie_sociale_solidaire_unite_legale` field in the output, alongside `est_ess`, to enable the website to issue a warning in the event of inconsistency? @XavierJp 
🟢 **Update:** `est_ess` is now the union of `est_ess_france` and `economie_sociale_solidaire_unite_legale`.