### PR TITLE
[MONITORING]feat: track api calls via Matomo

### DIFF
--- a/aio/aio-proxy/aio_proxy/response/build_api_response.py
+++ b/aio/aio-proxy/aio_proxy/response/build_api_response.py
@@ -4,6 +4,7 @@ from aio_proxy.decorators.http_exception import http_exception_handler
 from aio_proxy.request.search_params_builder import SearchParamsBuilder
 from aio_proxy.response.response_builder import ResponseBuilder
 from aio_proxy.search.es_search_runner import ElasticSearchRunner
+from aio_proxy.utils.matomo import track_event
 from aiohttp import web
 
 
@@ -21,6 +22,7 @@ def build_api_response(
         response in json format (results, total_results, page, per_page,
         total_pages)
     """
+    track_event(request)
     search_params = SearchParamsBuilder.extract_params(request, search_type)
     es_search_results = ElasticSearchRunner(search_params, search_type)
     formatted_response = ResponseBuilder(search_params, es_search_results)

--- a/aio/aio-proxy/aio_proxy/utils/matomo.py
+++ b/aio/aio-proxy/aio_proxy/utils/matomo.py
@@ -1,0 +1,54 @@
+import asyncio
+import hashlib
+import logging
+import os
+import random
+import time
+import urllib
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+ID_SITE = os.getenv("MATOMO_ID_SITE")
+TRACKING_URL = os.getenv("MATOMO_TRACKING_URL")
+# Probability of tracking the event (1 in 1000)
+TRACKING_PROBABILITY = 1 / 1000
+
+
+async def track_api_call_via_matomo(request):
+    try:
+        time.sleep(15)
+        rec = 1  # Required for tracking
+        url = f"https://recherche-entreprises.api.gouv.fr/{str(request.rel_url.query)}"
+        action_name = "Recherche API"
+        _id = generate_unique_visitor_id(request)
+
+        tracking_params = {
+            "idsite": ID_SITE,
+            "rec": rec,
+            "action_name": action_name,
+            "url": url,
+            "_id": _id,
+            "apiv": 1,
+        }
+
+        tracking_data = urllib.parse.urlencode(tracking_params)
+        tracking_url = TRACKING_URL + tracking_data
+        requests.get(tracking_url)
+    except Exception as error:
+        logging.info(f"Matomo logging failed: {error}")
+
+
+def generate_unique_visitor_id(request):
+    ip_address = request.headers.get("X-Forwarded-For") or request.remote
+    hashed_ip = hashlib.sha256(ip_address.encode("utf-8")).hexdigest()
+    return hashed_ip
+
+
+def track_event(request):
+    random_number = random.random()
+    if random_number < TRACKING_PROBABILITY:
+        loop = asyncio.get_event_loop()
+        return loop.create_task(track_api_call_via_matomo(request))

--- a/aio/aio-proxy/aio_proxy/utils/matomo.py
+++ b/aio/aio-proxy/aio_proxy/utils/matomo.py
@@ -16,7 +16,7 @@ TRACKING_URL = os.getenv("MATOMO_TRACKING_URL")
 TRACKING_PROBABILITY = 1 / 1000
 
 
-async def track_api_call_via_matomo(request):
+async def track_api_call_via_matomo(request, timeout=5):
     """
     Track an API call via Matomo.
 
@@ -48,7 +48,7 @@ async def track_api_call_via_matomo(request):
 
         tracking_data = urllib.parse.urlencode(tracking_params)
         tracking_url = TRACKING_URL + tracking_data
-        requests.get(tracking_url)
+        requests.get(tracking_url, timeout=timeout)
     except Exception as error:
         logging.info(f"Matomo logging failed: {error}")
 

--- a/aio/aio-proxy/aio_proxy/utils/matomo.py
+++ b/aio/aio-proxy/aio_proxy/utils/matomo.py
@@ -3,7 +3,6 @@ import hashlib
 import logging
 import os
 import random
-import time
 import urllib
 
 import requests
@@ -18,8 +17,21 @@ TRACKING_PROBABILITY = 1 / 1000
 
 
 async def track_api_call_via_matomo(request):
+    """
+    Track an API call via Matomo.
+
+    Args:
+        request: The web request object.
+
+    Raises:
+        Exception: If Matomo logging fails, an exception is caught and logged.
+
+    Notes:
+        This function tracks the API call with Matomo using
+        the provided request information, and the data is sent asynchronously.
+
+    """
     try:
-        time.sleep(15)
         rec = 1  # Required for tracking
         url = f"https://recherche-entreprises.api.gouv.fr/{str(request.rel_url.query)}"
         action_name = "Recherche API"
@@ -48,6 +60,9 @@ def generate_unique_visitor_id(request):
 
 
 def track_event(request):
+    """
+    Track an event based on a random probability.
+    """
     random_number = random.random()
     if random_number < TRACKING_PROBABILITY:
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
closes #324 
This PR introduces Matomo tracking code. Now, API calls will be tracked with a probability of 1 in 1000, providing a sampling mechanism for Matomo tracking.
depends on https://github.com/etalab/annuaire-entreprises-infrastructure/pull/32