### PR TITLE
Statut diffusion etab

### DIFF
--- a/aio/aio-proxy/aio_proxy/response/formatters/etablissements.py
+++ b/aio/aio-proxy/aio_proxy/response/formatters/etablissements.py
@@ -1,4 +1,7 @@
 from aio_proxy.response.formatters.enseignes import format_enseignes
+from aio_proxy.response.formatters.non_diffusible import (
+    hide_non_diffusible_etablissement_fields,
+)
 from aio_proxy.response.helpers import get_value
 from aio_proxy.response.unite_legale_model import Etablissement
 
@@ -56,9 +59,20 @@ def format_etablissement(source_etablissement):
         "numero_voie": get_field("numero_voie"),
         "region": get_field("region"),
         "siret": get_field("siret"),
+        "statut_diffusion_etablissement": get_field("statut_diffusion_etablissement"),
         "tranche_effectif_salarie": get_field("tranche_effectif_salarie"),
         "type_voie": get_field("type_voie"),
     }
+
+    is_non_diffusible = (
+        True if get_field("statut_diffusion_etablissement") == "P" else False
+    )
+
+    if is_non_diffusible:
+        formatted_etablissement = hide_non_diffusible_etablissement_fields(
+            formatted_etablissement
+        )
+
     return Etablissement(**formatted_etablissement)
 
 

--- a/aio/aio-proxy/aio_proxy/response/formatters/non_diffusible.py
+++ b/aio/aio-proxy/aio_proxy/response/formatters/non_diffusible.py
@@ -42,6 +42,7 @@ def hide_non_diffusible_etablissement_fields(etablissement):
             "[NON-DIFFUSIBLE]" for enseigne in etablissement["liste_enseignes"]
         ]
     non_diffusible_fields = [
+        "adresse",
         "cedex",
         "code_postal",
         "complement_adresse",

--- a/aio/aio-proxy/aio_proxy/response/unite_legale_model.py
+++ b/aio/aio-proxy/aio_proxy/response/unite_legale_model.py
@@ -44,6 +44,7 @@ class Etablissement(BaseModel):
     numero_voie: str | None = None
     region: str | None = None
     siret: str | None = None
+    statut_diffusion_etablissement: str | None = None
     tranche_effectif_salarie: str | None = None
     type_voie: str | None = None
 


### PR DESCRIPTION
depends on https://github.com/etalab/annuaire-entreprises-search-infra/pull/264
related to https://github.com/etalab/annuaire-entreprises-site/issues/842


This pull request introduces logic to include the `statut_diffusion_etablissement` in the payload. It also involves hiding certain fields from each `etablissement` if it is marked as "partiellement diffusible," regardless of the `statut_diffusion_unite_legale`.