### PR TITLE
chore: the SSH command exit status is always forwarded to the executor

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
           SSH_HOST: ${{ secrets[matrix.host] }}
 
       - name: Deploy to staging
-        run: ssh -i ./deploy.key www-data@$SSH_HOST 'python3 /opt/scripts/app-deploy-release/deploy.py /opt/git/releases/annuaire-entreprises-search-api https://github.com/etalab/annuaire-entreprises-search-api.git api --version github-action-deploy --versions_to_keep=5 | tee --append /var/log/deploy_annuaire-entreprises-search-api'
+        run: ssh -i ./deploy.key www-data@$SSH_HOST 'python3 /opt/scripts/app-deploy-release/deploy.py /opt/git/releases/annuaire-entreprises-search-api https://github.com/etalab/annuaire-entreprises-search-api.git api --version github-action-deploy --versions_to_keep=5 1> >(tee --append /var/log/deploy_annuaire-entreprises-search-api)'
         env:
           SSH_HOST: ${{ secrets[matrix.host] }}
 
@@ -75,7 +75,7 @@ jobs:
           SSH_HOST: ${{ secrets[matrix.host] }}
 
       - name: Deploy to production
-        run: ssh -i ./deploy.key www-data@$SSH_HOST 'python3 /opt/scripts/app-deploy-release/deploy.py /opt/git/releases/annuaire-entreprises-search-api https://github.com/etalab/annuaire-entreprises-search-api.git api --version github-action-deploy --versions_to_keep=5 | tee --append /var/log/deploy_annuaire-entreprises-search-api'
+        run: ssh -i ./deploy.key www-data@$SSH_HOST 'python3 /opt/scripts/app-deploy-release/deploy.py /opt/git/releases/annuaire-entreprises-search-api https://github.com/etalab/annuaire-entreprises-search-api.git api --version github-action-deploy --versions_to_keep=5 1> >(tee --append /var/log/deploy_annuaire-entreprises-search-api)'
         env:
           SSH_HOST: ${{ secrets[matrix.host] }}
 


### PR DESCRIPTION
Relates to :
- https://github.com/etalab/annuaire-entreprises-site/pull/929
- https://github.com/etalab/annuaire-entreprises-infrastructure/pull/84

---

Up until now, when an error occured during the deployment, it was not reported in the Github action. This was due to the presence of the pipe that was sending both the stdout & the stderr to the tee command.


---
### Before

expected : 
```
/usr/bin/docker
success
```

actual : 
```
/usr/bin/docker
success
```

```sh
ssh annuaire-entreprises-staging-www-1 'which docker | tee --append /tmp/debug_err' && echo 'success' || echo 'error' 
```

---
### After

expected : 
```
/usr/bin/docker
success
```

actual : 
```
/usr/bin/docker
success
```

```sh
ssh annuaire-entreprises-staging-www-1 'which docker 1> >(tee --append /tmp/debug_err)' && echo 'success' || echo 'error'
```


---
### Before

expected : "error"
actual : "success"

```sh
ssh annuaire-entreprises-staging-www-1 'which foobar | tee --append /tmp/debug_err' && echo 'success' || echo 'error' 
```

---
### After

expected : "error"
actual : "error"

```sh
ssh annuaire-entreprises-staging-www-1 'which foobar 1> >(tee --append /tmp/debug_err)' && echo 'success' || echo 'error'
```