### PR TITLE
[Bug][NonDiffusible]fix(search nd): filter on personne morale = true in text search

### DIFF
--- a/app/elastic/text_search.py
+++ b/app/elastic/text_search.py
@@ -65,7 +65,7 @@ def build_es_search_text_query(es_search_builder):
             "bool",
             should=[
                 Q("term", **{"unite_legale.statut_diffusion_unite_legale": "O"}),
-                Q("exists", field="unite_legale.est_personne_morale_insee"),
+                Q("term", **{"unite_legale.est_personne_morale_insee": True}),
             ],
             minimum_should_match=1,
         )


### PR DESCRIPTION
**Issue:**
The search algo only checks if the `est_personne_morale` field exists, not if it is `true`. As a result, the `dirigeants` fields (accessible via RNE data) remain searchable, which is why ND data appears when searching for a dirigeant’s name, e.g.:
[Search example](https://annuaire-entreprises.data.gouv.fr/rechercher?terme=M%C3%A9d%C3%A9ric+PENNANEC%27H)
(see also [#2058](https://github.com/annuaire-entreprises-data-gouv-fr/site/issues/2058).

**Root Cause:**
The absence of a strict check for `est_personne_morale === true` before exposing search results.

**Fix:**
Add an explicit check for `est_personne_morale === true` (or `statut_diffusion==O`) before allowing search.
