### PR TITLE
fix(payload): sort nature entreprise list

### DIFF
--- a/app/service/formatters/immatriculation.py
+++ b/app/service/formatters/immatriculation.py
@@ -43,4 +43,5 @@ def format_nature_entreprise(nature_entreprise):
         else:
             mapped_nature_entreprise.append(code)  # return nature as is if not found
 
+    # Sort alphabetically to ensure consistent ordering for e2e testing
     return sorted(mapped_nature_entreprise)

--- a/app/tests/e2e_tests/test_api.py
+++ b/app/tests/e2e_tests/test_api.py
@@ -805,6 +805,7 @@ def test_immatriculation(api_response_tester):
         "devise_capital": "EUR",
         "indicateur_associe_unique": False,
         "capital_social": 2084365041,
+        # Sorted alphabetically
         "nature_entreprise": [
             "Agent commercial",
             "Commerciale",


### PR DESCRIPTION
Otherwise the list order is different between envs, so e2e testing fails.