### PR TITLE
docs: update open api swagger

### DIFF
--- a/app/doc/open-api.yml
+++ b/app/doc/open-api.yml
@@ -8,7 +8,7 @@ info:
   description: >
     # Bienvenue sur la documentation interactive d'API Recherche d’entreprises !
 
-    L’API Recherche d’entreprises permet à tout le monde retrouver une entreprise,
+    L’API Recherche d’Entreprises permet à tout le monde retrouver une entreprise,
     une association, ou un service public en France. Elle propose un grand nombre de
     critères de recherche, en particulier la dénomination, l’adresse et les
     dirigeants ou élus.
@@ -26,7 +26,7 @@ info:
 
 
     **Attention :** cette API ne permet pas d'accèder aux données complètes de
-    la  base Sirene, mais uniquement de rechercher une entreprise, par sa
+    la base Sirene, mais uniquement de rechercher une entreprise par sa
     dénomination ou son adresse. Pour savoir comment obtenir les données
     complètes, consultez [notre fiche
     explicative.](https://api.gouv.fr/guides/quelle-api-sirene)
@@ -41,7 +41,7 @@ info:
 
     ## Limite des requêtes
 
-      Le serveur accepte un maximum de 7 requêtes par seconde. Au delà, un code 429
+    Le serveur accepte un maximum de 7 requêtes par seconde. Au delà, un code 429
     est renvoyé indiquant que la volumétrie d'appels a été dépassée.
 
 
@@ -640,6 +640,26 @@ paths:
           schema:
             type: integer
             default: 10
+        - name: page_etablissements
+          in: query
+          description: >-
+            Numéro de page pour la pagination des établissements connexes
+            (matching_etablissements).
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: sort_by_size
+          in: query
+          description: >-
+            Permet de trier les résultats par taille d'entreprise (nombre
+            d'établissements).
+          required: false
+          schema:
+            type: boolean
+            enum:
+              - true
+              - false
       responses:
         '200':
           description: >-
@@ -648,894 +668,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  results:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        siren:
-                          type: string
-                          example: "356000000"
-                          description: le numéro unique de l'entreprise
-                        nom_complet:
-                          type: string
-                          description: >-
-                            Champ construit depuis les champs de dénomination :
-                            dénomination de l'unité légale | Nom et prénom | Nom inconnu
-                            (dénomination usuelle : Construite en priorité à partir de
-                            la dénomination usuelle de l'établissement siège.
-                            Si cette dernière n'existe pas, elle est construite à
-                            partir des trois champs de dénomination usuelle de l'unité
-                            légale. source : base SIRENE) (sigle de l'unité légale)
-                          example: "la poste"
-                        nom_raison_sociale:
-                          type: string
-                          example: "LA POSTE"
-                          description: >-
-                            La raison sociale pour les personnes morales (source :
-                            base SIRENE).
-                        sigle:
-                          type: string
-                          nullable: true
-                          example: null
-                          description: >-
-                            Forme réduite de la raison sociale ou de la dénomination
-                            d'une personne morale ou d'un organisme public (source :
-                            base SIRENE).
-                        nombre_etablissements:
-                          type: integer
-                          title: Nombre des établissements de l'unité légale
-                          example: 12734
-                        nombre_etablissements_ouverts:
-                          type: integer
-                          title: Nombre des établissements ouverts de l'unité légale
-                          example: 9524
-                        siege:
-                          type: object
-                          properties:
-                            activite_principale:
-                              type: string
-                              example: "53.10Z"
-                              description: >-
-                                Activité principale de l'établissement (source : base
-                                SIRENE).
-                            activite_principale_naf25:
-                              type: string
-                              example: "53.10A"
-                              description: >-
-                                Activité principale de l'établissement selon la nomenclature NAF 2025
-                                (source : base SIRENE). Champ temporaire, supprimé à compter du 1er janvier 2027.
-                            activite_principale_registre_metier:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Activité principale de l'établissement au Registre
-                                des Métiers (source : base SIRENE).
-                            annee_tranche_effectif_salarie:
-                              type: string
-                              nullable: true
-                              example: "2020"
-                              description: >-
-                                Année de validité de la tranche d'effectif salarié de
-                                l'établissement (source : base SIRENE).
-                            adresse:
-                              type: string
-                              example: >-
-                                DIRECTION GENERALE DE LA POSTE 9 RUE DU COLONEL
-                                PIERRE AVIA 75015 PARIS 15
-                              description: >-
-                                Champ construit depuis les champs d'adresse de la
-                                base SIRENE : *complement adresse + numéro voie +
-                                indice repetition + type voie + libelle voie +
-                                distribution spéciale + (code postal + libelle
-                                commune |
-                                cedex + libelle cedex) + libelle commune étranger +
-                                libelle pays étranger*
-                            caractere_employeur:
-                              type: string
-                              example: "O"
-                              description: >-
-                                Caractère employeur du siège (source : base SIRENE).
-                            cedex:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Code cedex de l'établissement. Cette variable
-                                facultative est un élément constitutif de l'adresse.
-                                (source : base SIRENE).
-                            code_pays_etranger:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Code pays de l'adresse d'un établissement situé à
-                                l'étranger (source : base SIRENE).
-                            code_postal:
-                              type: string
-                              nullable: true
-                              pattern: >-
-                                ^((0[1-9])|([1-8][0-9])|(9[0-8])|(2A)|(2B))[0-9]{3}$
-                              example: "75015"
-                              description: >-
-                                Le code postal de l'adresse de l'établissement
-                                (source : base SIRENE).
-                            commune:
-                              type: string
-                              nullable: true
-                              example: "75115"
-                              description: >-
-                                Le code géographique de la commune de localisation de
-                                l'établissement, hors adresse à l'étranger (source :
-                                base SIRENE).
-                            complement_adresse:
-                              type: string
-                              nullable: true
-                              example: "DIRECTION GENERALE DE LA POSTE"
-                              description: >-
-                                Le code géographique de la commune de localisation de
-                                l'établissement, hors adresse à l'étranger (source :
-                                base SIRENE).
-                            date_creation:
-                              type: string
-                              nullable: true
-                              format: date
-                              description: >-
-                                Date de création de l'établissement (source : base
-                                SIRENE).
-                              example: "2003-01-01"
-                            date_fermeture:
-                              type: string
-                              nullable: true
-                              format: date
-                              description: >-
-                                Date de fermeture de l'établissement (source : base
-                                historique SIRENE).
-                            date_debut_activite:
-                              type: string
-                              format: date
-                              nullable: true
-                              example: "2014-04-29"
-                              description: >-
-                                Date de début d'une période de l'historique d'un
-                                établissement (source : base SIRENE).
-                            date_mise_a_jour:
-                              type: string
-                              format: date-time
-                              nullable: true
-                              example: "2023-09-21T03:34:50"
-                              description: >-
-                                Date du dernier traitement de l'établissement dans le
-                                répertoire Sirene (source : base SIRENE).
-                            departement:
-                              type: string
-                              nullable: true
-                              pattern: \b([013-8]\d?|2[aAbB1-9]?|9[0-59]?|97[12346])\b
-                              example: "75"
-                              description: >-
-                                Code département de l'établissement (source : base
-                                SIRENE).
-                            distribution_speciale:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Distribution spéciale de l'établissement (source :
-                                base SIRENE).
-                            est_siege:
-                              type: boolean
-                              example: true
-                              description: >-
-                                L'établissement est le siège de l'unité
-                                légale.
-                            etat_administratif:
-                              type: string
-                              example: "A"
-                              description: >-
-                                État administratif de l'établissement (A : Actif, F :
-                                Fermé) (source : base SIRENE).
-                            geo_id:
-                              nullable: true
-                              type: string
-                              example: "75115_2214"
-                              description: >-
-                                Identifiant géographique de l'adresse de
-                                l'établissement (source : base SIRENE géocodée par
-                                data.gouv. Cet identifiant est présent uniquement si la
-                                géolocalisation est issue de data.gouv).
-                            indice_repetition:
-                              nullable: true
-                              type: string
-                              example: null
-                              description: >-
-                                Indice de répétition du numéro dans la voie (B pour
-                                Bis, T pour TER, lettres ou chiffres pour identifier
-                                différents bâtiments à une même adresse...) (source :
-                                base SIRENE).
-                            latitude:
-                              type: string
-                              example: "48.83002"
-                              description: >-
-                                Latitude de l'établissement (source : la majorité des
-                                Siret utilisent le géocodage provenant de la base
-                                SIRENE géocodée par data.gouv, à l'exception de ceux
-                                modifiés après le début du mois en cours, pour lesquels
-                                la géolocalisation est directement extraite de
-                                la base SIRENE).
-                            libelle_cedex:
-                              type: string
-                              nullable: true
-                              description: >-
-                                Libellé associé au code cedex (source : base SIRENE).
-                              example: null
-                            libelle_commune:
-                              type: string
-                              example: "PARIS 15"
-                              description: >-
-                                Libellé de la commune (source : base SIRENE).
-                            libelle_commune_etranger:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Libellé de la commune pour un établissement situé à
-                                l'étranger (source : base SIRENE).
-                            libelle_pays_etranger:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Libellé du pays pour un établissement situé à
-                                l'étranger (source : base SIRENE).
-                            libelle_voie:
-                              type: string
-                              example: "DU COLONEL PIERRE AVIA"
-                              description: >-
-                                Libellé de la voie (source : base SIRENE).
-                            liste_enseignes:
-                              type: array
-                              nullable: true
-                              items:
-                                type: string
-                              example: [ "LA POSTE" ]
-                              description: >-
-                                Liste des enseignes de l'établissement (source : base
-                                SIRENE).
-                            liste_finess:
-                              type: array
-                              nullable: true
-                              description: >-
-                                Liste des identifiants FINESS Géographiques de l'établissement
-                                (source : Ministère des Solidarités et de la Santé ).
-                              items:
-                                type: string
-                                nullable: true
-                              example: ["950000364"]
-                            liste_idcc:
-                              type: array
-                              description: >-
-                                Liste des conventions collectives de l'établissement
-                                (source : Ministère du travail).
-                              items:
-                                type: string
-                              example: ["0923"]
-                            liste_finess_juridique:
-                              type: array
-                              description: >-
-                                Liste des identifiants FINESS Juridiques de l'entreprise
-                                et de ses établissements.
-                                (source : Ministère des Solidarités et de la Santé ).
-                              items:
-                                type: string
-                              example: ["010003846"]
-                            liste_id_bio:
-                              type: array
-                              description: >-
-                                Liste des identifiants bio de l'établissement
-                                (source : Agence Bio).
-                              items:
-                                type: string
-                              example: ["0923"]
-                            liste_rge:
-                              type: array
-                              items:
-                                type: string
-                              description: >-
-                                Liste des identifiants RGE de l'établissement (source
-                                : ADEME).
-                              example: ["4131D111", "7122D111"]
-                            liste_uai:
-                              type: array
-                              items:
-                                type: string
-                              description: >-
-                                Liste des identifiants UAI de l'établissements
-                                (source : Ministère de l'enseignement supérieur et de
-                                la recherche).
-                              example: ["0170100S"]
-                            longitude:
-                              type: string
-                              example: "2.275688"
-                              description: >-
-                                Longitude de l'établissement (source : la majorité des
-                                siret utilisent le géocodage provenant de la base
-                                SIRENE géocodée par data.gouv, à l'exception de ceux
-                                modifiés après le début du mois en cours, pour lesquels
-                                la géolocalisation est directement extraite de
-                                la base SIRENE).
-                            nom_commercial:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Dénomination usuelle de l'établissement (source :
-                                base SIRENE).
-                            numero_voie:
-                              type: string
-                              example: "9"
-                              description: >-
-                                Numéro dans la voie (source : base SIRENE).
-                            region:
-                              type: string
-                              nullable: true
-                              example: "11"
-                              description: >-
-                                Code région de l'établissement (source : base
-                                SIRENE).
-                            epci:
-                              type: string
-                              nullable: true
-                              example: "200058519"
-                              description: >-
-                                Numéro siren de l'EPCI.
-                            siret:
-                              type: string
-                              example: "35600000000048"
-                              description: le numéro unique de l'établissement siège.
-                            statut_diffusion_etablissement:
-                              type: string
-                              example: "O"
-                              description: >-
-                                Statut de diffusion de l'établissement.
-                                Toutes les établissements diffusibles ont le statut de
-                                diffusion à "O". Les établissements ayant fait
-                                l'objet d'une demande d'opposition ont le statut de
-                                diffusion à "P" pour diffusion partielle
-                                (source : base SIRENE).
-                            tranche_effectif_salarie:
-                              type: string
-                              example: "41"
-                              description: >-
-                                Tranche d'effectif salarié de l'établissement (source
-                                : base SIRENE).
-                            type_voie:
-                              type: string
-                              example: "RUE"
-                              description: >-
-                                Type de voie de l'adresse (source : base SIRENE).
-                        date_creation:
-                          type: string
-                          format: date
-                          example: "1991-01-01"
-                          description: >-
-                            Date de création de l'unité légale (source : base SIRENE).
-                        date_fermeture:
-                          type: string
-                          format: date
-                          description: >-
-                            Date de fermeture de l'unité légale (source : base
-                            historique SIRENE).
-                        tranche_effectif_salarie:
-                          type: string
-                          example: "53"
-                          description: >-
-                            Tranche d'effectif salarié de l'unité légale (source :
-                            base SIRENE).
-                        annee_tranche_effectif_salarie:
-                          type: string
-                          example: "2020"
-                          description: >-
-                            Année de validité de la tranche d'effectif salarié de
-                            l'unité légale (source : base SIRENE).
-                        date_mise_a_jour:
-                          type: string
-                          format: date
-                          example: "2022-05-31"
-                          description: >-
-                            Date de la dernière modification d'une variable de niveau
-                            unité légale, qu'elle soit historisée ou non (source :
-                            base SIRENE).
-                        categorie_entreprise:
-                          type: string
-                          example: "GE"
-                          description: >-
-                            Catégorie d'entreprise de l'unité légale (source : base
-                            SIRENE).
-                        caractere_employeur:
-                          type: string
-                          example: "O"
-                          description: >-
-                            Caractère employeur de l'unité légale (source : base
-                            SIRENE).
-                        annee_categorie_entreprise:
-                          type: string
-                          example: "2020"
-                          description: >-
-                            Année de validité correspondant à la catégorie
-                            d'entreprise diffusée (source : base
-                            SIRENE).
-                        etat_administratif:
-                          type: string
-                          example: "A"
-                          description: >-
-                            État administratif de l'unité légale (source : base SIRENE).
-                        nature_juridique:
-                          type: string
-                          example: "5510"
-                          description: >-
-                            Catégorie juridique de l'unité légale (source : base SIRENE).
-                        activite_principale:
-                          type: string
-                          example: "53.10Z"
-                          description: >-
-                            Code de l'activité principale exercée (APE) par l'unité
-                            légale (source : base SIRENE).
-                        activite_principale_naf25:
-                          type: string
-                          example: "53.10A"
-                          description: >-
-                            Activité principale de l'unité légale selon la nomenclature NAF 2025
-                            (source : base SIRENE). Champ temporaire, supprimé à compter du 1er janvier 2027.
-                        section_activite_principale:
-                          type: string
-                          example: "H"
-                          description: Calculée à partir de l'activité principale.
-                        statut_diffusion:
-                          type: string
-                          example: "O"
-                          description: >-
-                            Statut de diffusion de l'unité légale.
-                            Toutes les unités légales diffusibles ont le statut de
-                            diffusion à "O". Les unités légales ayant fait l'objet d'une demande d'opposition ont le statut de diffusion à "P" pour diffusion partielle (source : base SIRENE).
-                        matching_etablissements:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              activite_principale:
-                                type: string
-                                example: "53.10Z"
-                                description: >-
-                                  Activité principale de l'établissement (source :
-                                  base SIRENE).
-                              activite_principale_naf25:
-                                type: string
-                                example: "53.10A"
-                                description: >-
-                                  Activité principale de l'établissement selon la nomenclature NAF 2025
-                                  (source : base SIRENE). Champ temporaire, supprimé à compter du 1er janvier 2027.
-                              adresse:
-                                type: string
-                                example: >-
-                                  19 RUE DE LA POSTE 31700 CORNEBARRIEU
-                                description: >-
-                                  Champ construit depuis les champs d'adresse de la
-                                  base SIRENE : *complement adresse + numéro voie +
-                                  indice repetition + type voie + libelle voie +
-                                  distribution spéciale + (code postal + libelle
-                                  commune | cedex + libelle cedex) + libelle commune
-                                  étranger + libelle pays étranger*
-                              annee_tranche_effectif_salarie:
-                                type: string
-                                nullable: true
-                                example: "2020"
-                                description: >-
-                                  Année de validité de la tranche d'effectif salarié de
-                                  l'établissement (source : base SIRENE).
-                              ancien_siege:
-                                type: boolean
-                                example: false
-                                description: >-
-                                  L'établissement était le siège de
-                                  l'unité légale (source : base SIRENE).
-                              caractere_employeur:
-                                type: string
-                                example: "O"
-                                description: >-
-                                  Caractère employeur de l'établissement (source : base SIRENE).
-                              code_postal:
-                                type: string
-                                nullable: true
-                                pattern: >-
-                                  ^((0[1-9])|([1-8][0-9])|(9[0-8])|(2A)|(2B))[0-9]{3}$
-                                example: "75015"
-                                description: >-
-                                  Le code postal de l'adresse de l'établissement
-                                  (source : base SIRENE).
-                              commune:
-                                type: string
-                                example: "75115"
-                                description: >-
-                                  Le code géographique de la commune de localisation de
-                                  l'établissement, hors adresse à l'étranger (source :
-                                  base SIRENE).
-                              date_creation:
-                                type: string
-                                nullable: true
-                                format: date
-                                description: >-
-                                  Date de création de l'établissement (source : base
-                                  SIRENE).
-                              date_debut_activite:
-                                type: string
-                                format: date
-                                nullable: true
-                                example: "2014-04-29"
-                                description: >-
-                                  Date de début d'une période de l'historique d'un
-                                  établissement (source : base SIRENE).
-                              date_fermeture:
-                                type: string
-                                nullable: true
-                                format: date
-                                description: >-
-                                  Date de fermeture de l'établissement (source : base
-                                  historique SIRENE).
-                              epci:
-                                type: string
-                                nullable: true
-                                example: "200058519"
-                                description: >-
-                                  Numéro siren de l'EPCI.
-                              est_siege:
-                                type: boolean
-                                example: false
-                                description: >-
-                                  L'établissement est le siège de l'unité
-                                  légale.
-                              etat_administratif:
-                                type: string
-                                example: "A"
-                                description: >-
-                                  État administratif de l'établissement (A : Actif, F :
-                                  Fermé) (source : base SIRENE).
-                              geo_id:
-                                nullable: true
-                                type: string
-                                example: "31150_0157_00019"
-                                description: >-
-                                  Identifiant géographique de l'adresse de
-                                  l'établissement (source : base SIRENE géocodée par
-                                  data.gouv. Cet identifiant est présent uniquement si
-                                  la géolocalisation est issue de data.gouv).
-                              latitude:
-                                type: string
-                                example: "48.83002"
-                                description: >-
-                                  Latitude de l'établissement (source : la majorité des
-                                  siret utilisent le géocodage provenant de la base
-                                  SIRENE géocodée par data.gouv, à l'exception de ceux
-                                  modifiés après le début du mois en cours, pour lesquels
-                                  la géolocalisation est directement extraite de
-                                  la base SIRENE).
-                              libelle_commune:
-                                type: string
-                                example: "PARIS 15"
-                                description: >-
-                                  Libellé de la commune (source : base SIRENE).
-                              liste_enseignes:
-                                type: array
-                                nullable: true
-                                items:
-                                  type: string
-                                example: [ "LA POSTE" ]
-                                description: >-
-                                  Liste des enseignes de l'établissement (source : base
-                                  SIRENE).
-                              liste_finess:
-                                type: array
-                                nullable: true
-                                description: >-
-                                  Liste des identifiants FINESS Géographiques de l'établissement
-                                  (source : Ministère des Solidarités et de la Santé ).
-                                items:
-                                  type: string
-                                  nullable: true
-                                example: [ "950000364" ]
-                              liste_idcc:
-                                type: array
-                                description: >-
-                                  Liste des conventions collectives de l'établissement
-                                  (source : Ministère du travail).
-                                items:
-                                  type: string
-                                example: [ "0923" ]
-                              liste_finess_juridique:
-                                type: array
-                                description: >-
-                                  Liste des identifiants FINESS Juridiques de l'entreprise
-                                  et de ses établissements.
-                                  (source : Ministère des Solidarités et de la Santé ).
-                                items:
-                                  type: string
-                                example: [ "750100042" ]
-                              liste_id_organisme_formation:
-                                type: array
-                                items:
-                                  type: string
-                                description: >-
-                                  Liste des numéro de déclaration d'activité des
-                                  établissement organismes de formation
-                                  (source : Ministère du Travail).
-                              liste_id_bio:
-                                type: array
-                                description: >-
-                                  Liste des identifiants bio de l'établissement
-                                  (source : Agence Bio).
-                                items:
-                                  type: string
-                                example: ["0923"]
-                              liste_rge:
-                                type: array
-                                items:
-                                  type: string
-                                description: >-
-                                  Liste des identifiants RGE de l'établissement
-                                  (source : ADEME).
-                                example: [ "4131D111", "7122D111" ]
-                              liste_uai:
-                                type: array
-                                items:
-                                  type: string
-                                description: >-
-                                  Liste des identifiants UAI de l'établissements
-                                  (source : Ministère de l'enseignement supérieur et
-                                  de la recherche).
-                                example: [ "0170100S" ]
-                              longitude:
-                                type: string
-                                example: "2.275688"
-                                description: >-
-                                  Longitude de l'établissement (source : la majorité des
-                                  siret utilisent le géocodage provenant de la base
-                                  SIRENE géocodée par data.gouv, à l'exception de ceux
-                                  modifiés après le début du mois en cours, pour
-                                  lesquels la géolocalisation est directement extraite
-                                  de la base SIRENE).
-                              nom_commercial:
-                                type: string
-                                nullable: true
-                                example: null
-                                description: >-
-                                  Dénomination usuelle de l'établissement (source :
-                                  base SIRENE).
-                              region:
-                                type: string
-                                nullable: true
-                                example: "11"
-                                description: >-
-                                  Région de l'établissement (source :
-                                  base SIRENE).
-                              siret:
-                                type: string
-                                example: "35600000000048"
-                                description: le numéro unique de l'établissement.
-                              statut_diffusion_etablissement:
-                                type: string
-                                example: "O"
-                                description: >-
-                                  Statut de diffusion de l'établissement.
-                                  Toutes les établissements diffusibles ont le statut de
-                                  diffusion à "O". Les établissements ayant fait
-                                  l'objet d'une demande d'opposition ont le statut de
-                                  diffusion à "P" pour diffusion partielle
-                                  (source : base SIRENE).
-                              tranche_effectif_salarie:
-                                type: string
-                                nullable: true
-                                example: "12"
-                                description: >-
-                                  Tranche d'effectif salarié de l'établissement
-                                  (source : base SIRENE).
-                        dirigeants:
-                          type: array
-                          items:
-                            oneOf:
-                              - $ref: '#/components/schemas/dirigeant_pp'
-                              - $ref: '#/components/schemas/dirigeant_pm'
-                        finances:
-                          type: object
-                          $ref: >-
-                            #/components/schemas/finances
-                        complements:
-                          type: object
-                          properties:
-                            collectivite_territoriale:
-                              type: object
-                              $ref: >-
-                                #/components/schemas/collectivite_territoriale
-                            convention_collective_renseignee:
-                              type: boolean
-                              description: >-
-                                Indique si au moins un établissement a une
-                                convention collective renseignée
-                            liste_idcc:
-                              type: array
-                              description: >-
-                                Liste des conventions collectives de l'unité légale
-                                (source : Ministère du travail)
-                              items:
-                                  type: string
-                            liste_finess_juridique:
-                              type: array
-                              description: >-
-                                Liste des identifiants FINESS Juridiques de l'entreprise
-                                et de ses établissements.
-                                (source : Ministère des Solidarités et de la Santé ).
-                              items:
-                                  type: string
-                            egapro_renseignee:
-                              type: boolean
-                              description: >-
-                                Indique si au moins un établissement a un
-                                indice égalité professionnel H/F renseigné
-                            est_achats_responsables:
-                              type: boolean
-                              description: >-
-                                Indique si l'entreprise est labelisée
-                                Relations fournisseurs et achats responsables (RFAR)
-                            est_alim_confiance:
-                              type: boolean
-                              description: >-
-                                Indique si l'entreprise a au moins un établissement avec un
-                                résultat de contrôle sanitaire Alim'Confiance.
-                            est_association:
-                              type: boolean
-                              example: false
-                              description: >-
-                                Association (source : INSEE)
-                            est_bio:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant au moins un établissement certifié bio
-                                (source: Agence Bio)
-                            est_entrepreneur_individuel:
-                              type: boolean
-                              description: Entreprise individuelle
-                              example: false
-                            est_entrepreneur_spectacle:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant une licence d'entrepreneur du
-                                spectacle (source : Ministère de la Culture)
-                              example: false
-                            est_ess:
-                              type: boolean
-                              description: >-
-                                Entreprise d'économie sociale et solidaire
-                                (source : ESS France et INSEE)
-                              example: false
-                            est_finess:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant au moins un établissement FINESS
-                                (source : Ministère des Solidarités et de la Santé)
-                              example: false
-                            est_organisme_formation:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant au moins un établissement organisme de
-                                formation (source : Ministère du Travail)
-                            est_patrimoine_vivant:
-                              type: boolean
-                              description: >-
-                                Entreprise du Patrimoine Vivant (EPV)
-                            est_qualiopi:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant une certification de la
-                                marque « Qualiopi » (source : Ministère du Travail)
-                            liste_id_organisme_formation:
-                              type: array
-                              description: >-
-                                Liste des numéro de déclaration d’activité des
-                                établissement organismes de formation
-                                (source : Ministère du Travail).
-                              items:
-                                type: string
-                              example: [ "7423P001123" ]
-                            est_rge:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant au moins un établissement RGE
-                                (source : ADEME)
-                              example: false
-                            est_siae:
-                              type: boolean
-                              description: >-
-                                Structure d'insertion par l'activité économique
-                                (source : Marché de l'Inclusion)
-                              example: false
-                            est_service_public:
-                              type: boolean
-                              description: >-
-                                Uniquement les structures reconnues comme administration.
-
-                                Attention : Ce champ se base sur cette liste
-                                <a href=https://www.data.gouv.fr/fr/datasets/liste-des-administrations-francaises/ici</a>.
-
-                                Ce champ n'est pas exhaustif et peut retourner des faux positifs.
-                              example: false
-                            est_l100_3:
-                              type: boolean
-                              description: >-
-                                Uniquement les structures reconnues comme administration au sens de l'artcile L.100-3.
-
-                                Attention : Ce champ se base sur cette liste
-                                <a href=https://www.data.gouv.fr/fr/datasets/liste-des-administrations-francaises/ici</a>.
-
-                                Ce champ n'est pas exhaustif et peut retourner des faux positifs.
-                              example: false
-                            est_societe_mission:
-                              type: boolean
-                              example: false
-                              description: >-
-                                Société qui appartient au champ des sociétés à
-                                mission.
-                            est_uai:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant au moins un établissement UAI
-                                (source : Ministère de l'enseignement supérieur et de
-                                la recherche)
-                              example: false
-                            bilan_ges_renseigne:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant un bilan ges publié
-                                (source : ADEME)
-                              example: false
-                            identifiant_association:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Numéro au Répertoire National des Associations (RNA)
-                                (source : base SIRENE)
-                            statut_bio:
-                              type: boolean
-                              description: >-
-                                Statut des établissements ayant fait une demande de
-                                certification bio
-                                (source : Agence Bio)
-                            statut_entrepreneur_spectacle:
-                              type: string
-                              nullable: true
-                              description: >-
-                                Statut des établissements ayant fait une demande de
-                                licence d'entrepreneur du spectacle
-                                (source : Ministère de la Culture)
-                            type_siae:
-                              type: string
-                              nullable: true
-                              description: >-
-                                Type de structure de l'inclusion
-                                (source : Marché de l'Inclusion)
-                  total_results:
-                    type: integer
-                  page:
-                    type: integer
-                    default: 1
-                  per_page:
-                    type: integer
-                    default: 10
-                    description: Nombre de résultats par page, limité à 25.
-                  total_pages:
-                    type: integer
-                    example: 1000
+                $ref: '#/components/schemas/payload'
         '400':
           description: Requête incorrecte.
           content:
@@ -1708,6 +841,26 @@ paths:
           schema:
             type: integer
             default: 10
+        - name: page_etablissements
+          in: query
+          description: >-
+            Numéro de page pour la pagination des établissements connexes
+            (matching_etablissements).
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: sort_by_size
+          in: query
+          description: >-
+            Permet de trier les résultats par taille d'entreprise (nombre
+            d'établissements).
+          required: false
+          schema:
+            type: boolean
+            enum:
+              - true
+              - false
       responses:
         '200':
           description: >-
@@ -1716,885 +869,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  results:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        siren:
-                          type: string
-                          example: "356000000"
-                          description: le numéro unique de l'entreprise
-                        nom_complet:
-                          type: string
-                          description: >-
-                            Champ construit depuis les champs de dénomination :
-                            dénomination de l'unité légale | Nom et prénom | Nom inconnu
-                            (dénomination usuelle : Construite en priorité à partir de
-                            la dénomination usuelle de l'établissement siège.
-                            Si cette dernière n'existe pas, elle est construite à
-                            partir des trois champs de dénomination usuelle de l'unité
-                            légale. source : base SIRENE) (sigle de l'unité légale)
-                          example: "la poste"
-                        nom_raison_sociale:
-                          type: string
-                          example: "LA POSTE"
-                          description: >-
-                            La raison sociale pour les personnes morales (source :
-                            base SIRENE).
-                        sigle:
-                          type: string
-                          nullable: true
-                          example: null
-                          description: >-
-                            Forme réduite de la raison sociale ou de la dénomination
-                            d'une personne morale ou d'un organisme public (source :
-                            base SIRENE).
-                        nombre_etablissements:
-                          type: integer
-                          title: Nombre des établissements de l'unité légale
-                          example: 12734
-                        nombre_etablissements_ouverts:
-                          type: integer
-                          title: Nombre des établissements ouverts de l'unité légale.
-                          example: 9524
-                        siege:
-                          type: object
-                          properties:
-                            activite_principale:
-                              type: string
-                              example: "53.10Z"
-                              description: >-
-                                Activité principale de l'établissement (source : base
-                                SIRENE).
-                            activite_principale_naf25:
-                              type: string
-                              example: "53.10A"
-                              description: >-
-                                Activité principale de l'établissement selon la nomenclature NAF 2025
-                                (source : base SIRENE). Champ temporaire, supprimé à compter du 1er janvier 2027.
-                            activite_principale_registre_metier:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Activité principale de l'établissement au Registre
-                                des Métiers (source : base SIRENE).
-                            annee_tranche_effectif_salarie:
-                              type: string
-                              nullable: true
-                              example: "2020"
-                              description: >-
-                                Année de validité de la tranche d'effectif salarié de
-                                l'établissement (source : base SIRENE).
-                            adresse:
-                              type: string
-                              example: >-
-                                DIRECTION GENERALE DE LA POSTE 9 RUE DU COLONEL
-                                PIERRE AVIA 75015 PARIS 15
-                              description: >-
-                                Champ construit depuis les champs d'adresse de la
-                                base SIRENE : *complement adresse + numéro voie +
-                                indice repetition + type voie + libelle voie +
-                                distribution spéciale + (code postal + libelle commune |
-                                cedex + libelle cedex) + libelle commune étranger +
-                                libelle pays étranger*
-                            caractere_employeur:
-                              type: string
-                              example: "O"
-                              description: >-
-                                Caractère employeur du siège (source : base SIRENE).
-                            cedex:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Code cedex de l'établissement. Cette variable
-                                facultative est un élément constitutif de l'adresse.
-                                (source : base SIRENE).
-                            code_pays_etranger:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Code pays de l'adresse d'un établissement situé à
-                                l'étranger (source : base SIRENE).
-                            code_postal:
-                              type: string
-                              nullable: true
-                              pattern: >-
-                                ^((0[1-9])|([1-8][0-9])|(9[0-8])|(2A)|(2B))[0-9]{3}$
-                              example: "75015"
-                              description: >-
-                                Le code postal de l'adresse de l'établissement
-                                (source : base SIRENE).
-                            commune:
-                              type: string
-                              nullable: true
-                              example: "75115"
-                              description: >-
-                                Le code géographique de la commune de localisation de
-                                l'établissement, hors adresse à l'étranger (source :
-                                base SIRENE).
-                            complement_adresse:
-                              type: string
-                              nullable: true
-                              example: "DIRECTION GENERALE DE LA POSTE"
-                              description: >-
-                                Le code géographique de la commune de localisation de
-                                l'établissement, hors adresse à l'étranger (source :
-                                base SIRENE).
-                            date_creation:
-                              type: string
-                              nullable: true
-                              format: date
-                              description: >-
-                                Date de création de l'établissement (source : base
-                                SIRENE).
-                              example: "2003-01-01"
-                            date_fermeture:
-                              type: string
-                              nullable: true
-                              format: date
-                              description: >-
-                                Date de fermeture de l'établissement (source : base
-                                historique SIRENE).
-                            date_debut_activite:
-                              type: string
-                              format: date
-                              nullable: true
-                              example: "2014-04-29"
-                              description: >-
-                                Date de début d'une période de l'historique d'un
-                                établissement (source : base SIRENE).
-                            date_mise_a_jour:
-                              type: string
-                              format: date-time
-                              nullable: true
-                              example: "2023-09-21T03:34:50"
-                              description: >-
-                                Date du dernier traitement de l'établissement dans le
-                                répertoire Sirene (source : base SIRENE).
-                            departement:
-                              type: string
-                              nullable: true
-                              pattern: \b([013-8]\d?|2[aAbB1-9]?|9[0-59]?|97[12346])\b
-                              example: "75"
-                              description: >-
-                                Code département de l'établissement (source : base
-                                SIRENE).
-                            distribution_speciale:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Distribution spéciale de l'établissement (source :
-                                base SIRENE).
-                            est_siege:
-                              type: boolean
-                              example: true
-                              description: >-
-                                L'établissement est le siège de l'unité
-                                légale.
-                            etat_administratif:
-                              type: string
-                              example: "A"
-                              description: >-
-                                État administratif de l'établissement (A : Actif, F :
-                                Fermé) (source : base SIRENE).
-                            geo_id:
-                              nullable: true
-                              type: string
-                              example: "75115_2214"
-                              description: >-
-                                Identifiant géographique de l'adresse de
-                                l'établissement (source : base SIRENE géocodée par
-                                data.gouv. Cet identifiant est présent uniquement si la
-                                géolocalisation est issue de data.gouv).
-                            indice_repetition:
-                              nullable: true
-                              example: null
-                              description: >-
-                                Indice de répétition du numéro dans la voie (B pour
-                                Bis, T pour TER, lettres ou chiffres pour identifier
-                                différents bâtiments à une même adresse...) (source :
-                                base SIRENE).
-                            latitude:
-                              type: string
-                              example: "48.83002"
-                              description: >-
-                                Latitude de l'établissement (source : la majorité des
-                                siret utilisent le géocodage provenant de la base
-                                SIRENE géocodée par data.gouv, à l'exception de ceux
-                                modifiés après le début du mois en cours, pour lesquels
-                                la géolocalisation est directement extraite de
-                                la base SIRENE).
-                            libelle_cedex:
-                              type: string
-                              nullable: true
-                              description: >-
-                                Libellé associé au code cedex (source : base SIRENE).
-                              example: null
-                            libelle_commune:
-                              type: string
-                              example: "PARIS 15"
-                              description: >-
-                                Libellé de la commune (source : base SIRENE).
-                            libelle_commune_etranger:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Libellé de la commune pour un établissement situé à
-                                l'étranger (source : base SIRENE).
-                            libelle_pays_etranger:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Libellé du pays pour un établissement situé à
-                                l'étranger (source : base SIRENE).
-                            libelle_voie:
-                              type: string
-                              example: "DU COLONEL PIERRE AVIA"
-                              description: >-
-                                Libellé de la voie (source : base SIRENE).
-                            liste_enseignes:
-                              type: array
-                              nullable: true
-                              items:
-                                type: string
-                              example: [ "LA POSTE" ]
-                              description: >-
-                                Liste des enseignes de l'établissement (source : base
-                                SIRENE).
-                            liste_finess:
-                              type: array
-                              nullable: true
-                              description: >-
-                                Liste des identifiants FINESS Géographiques de l'établissement
-                                (source : Ministère des Solidarités et de la Santé ).
-                              items:
-                                type: string
-                                nullable: true
-                              example: [ "950000364" ]
-                            liste_idcc:
-                              type: array
-                              description: >-
-                                Liste des conventions collectives de l'établissement
-                                (source : Ministère du travail).
-                              items:
-                                type: string
-                              example: [ "0923" ]
-                            liste_finess_juridique:
-                              type: array
-                              description: >-
-                                Liste des identifiants FINESS Juridiques de l'entreprise
-                                et de ses établissements.
-                                (source : Ministère des Solidarités et de la Santé ).
-                              items:
-                                type: string
-                              example: [ "750100042" ]
-                            liste_id_bio:
-                              type: array
-                              description: >-
-                                Liste des identifiants bio de l'établissement
-                                (source : Agence Bio).
-                              items:
-                                type: string
-                              example: ["7423P001123"]
-                            liste_rge:
-                              type: array
-                              items:
-                                type: string
-                              description: >-
-                                Liste des identifiants RGE de l'établissement (source
-                                : ADEME).
-                              example: [ "4131D111", "7122D111" ]
-                            liste_uai:
-                              type: array
-                              items:
-                                type: string
-                              description: >-
-                                Liste des identifiants UAI de l'établissement (source
-                                : Ministère de l'enseignement supérieur et de la
-                                recherche).
-                              example: [ "0170100S" ]
-                            longitude:
-                              type: string
-                              example: "2.275688"
-                              description: >-
-                                Longitude de l'établissement (source : la majorité des
-                                siret utilisent le géocodage provenant de la base
-                                SIRENE géocodée par data.gouv, à l'exception de ceux
-                                modifiés après le début du mois en cours, pour lesquels
-                                la géolocalisation est directement extraite de
-                                la base SIRENE).
-                            nom_commercial:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Dénomination usuelle de l'établissement (source :
-                                base SIRENE).
-                            numero_voie:
-                              type: string
-                              example: "9"
-                              description: >-
-                                Numéro dans la voie (source : base SIRENE).
-                            region:
-                              type: string
-                              nullable: true
-                              example: "11"
-                              description: >-
-                                Code région de l'établissement (source : base
-                                SIRENE).
-                            epci:
-                              type: string
-                              nullable: true
-                              example: "200058519"
-                              description: >-
-                                Numéro siren de l'EPCI.
-                            siret:
-                              type: string
-                              example: "35600000000048"
-                              description: le numéro unique de l'établissement siège.
-                            statut_diffusion_etablissement:
-                              type: string
-                              example: "O"
-                              description: >-
-                                Statut de diffusion de l'établissement.
-                                Toutes les établissements diffusibles ont le statut de
-                                diffusion à "O". Les établissements ayant fait
-                                l'objet d'une demande d'opposition ont le statut de
-                                diffusion à "P" pour diffusion partielle
-                                (source : base SIRENE).
-                            tranche_effectif_salarie:
-                              type: string
-                              example: "41"
-                              description: >-
-                                Tranche d'effectif salarié de l'établissement (source
-                                : base SIRENE).
-                            type_voie:
-                              type: string
-                              example: "RUE"
-                              description: >-
-                                Type de voie de l'adresse (source : base SIRENE).
-                        date_creation:
-                          type: string
-                          format: date
-                          example: "1991-01-01"
-                          description: >-
-                            Date de création de l'unité légale (source : base SIRENE).
-                        date_fermeture:
-                          type: string
-                          format: date
-                          description: >-
-                            Date de fermeture de l'unité légale (source : base
-                            historique SIRENE).
-                        tranche_effectif_salarie:
-                          type: string
-                          example: "53"
-                          description: >-
-                            Tranche d'effectif salarié de l'unité légale (source :
-                            base SIRENE).
-                        annee_tranche_effectif_salarie:
-                          type: string
-                          example: "2020"
-                          description: >-
-                            Année de validité de la tranche d'effectif salarié de
-                            l'unité légale (source : base SIRENE).
-                        date_mise_a_jour:
-                          type: string
-                          format: date
-                          example: "2022-05-31"
-                          description: >-
-                            Date de la dernière modification d'une variable de niveau
-                            unité légale, qu'elle soit historisée ou non (source :
-                            base SIRENE).
-                        categorie_entreprise:
-                          type: string
-                          example: "GE"
-                          description: >-
-                            Catégorie d'entreprise de l'unité légale (source : base
-                            SIRENE).
-                        caractere_employeur:
-                          type: string
-                          example: "O"
-                          description: >-
-                            Caractère employeur de l'unité légale (source : base
-                            SIRENE).
-                        annee_categorie_entreprise:
-                          type: string
-                          example: "2020"
-                          description: >-
-                            Année de validité correspondant à la catégorie
-                            d'entreprise diffusée (source : base
-                            SIRENE).
-                        etat_administratif:
-                          type: string
-                          example: "A"
-                          description: >-
-                            État administratif de l'unité légale (source : base SIRENE).
-                        nature_juridique:
-                          type: string
-                          example: "5510"
-                          description: >-
-                            Catégorie juridique de l'unité légale (source : base
-                            SIRENE).
-                        activite_principale:
-                          type: string
-                          example: "53.10Z"
-                          description: >-
-                            Code de l'activité principale exercée (APE) par l'unité
-                            légale (source : base SIRENE).
-                        activite_principale_naf25:
-                          type: string
-                          example: "53.10A"
-                          description: >-
-                            Activité principale de l'unité légale selon la nomenclature NAF 2025
-                            (source : base SIRENE). Champ temporaire, supprimé à compter du 1er janvier 2027.
-                        section_activite_principale:
-                          type: string
-                          example: "H"
-                          description: Calculée à partir de l'activité principale.
-                        statut_diffusion:
-                          type: string
-                          example: "O"
-                          description: >-
-                            Statut de diffusion de l'unité légale.
-                            Toutes les unités légales diffusibles ont le statut de
-                            diffusion à "O". Les unités légales ayant fait l'objet d'une demande d'opposition ont le statut de diffusion à "P" pour diffusion partielle (source : base SIRENE).
-                        matching_etablissements:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              activite_principale:
-                                type: string
-                                example: "53.10Z"
-                                description: >-
-                                  Activité principale de l'établissement (source :
-                                  base SIRENE)
-                              activite_principale_naf25:
-                                type: string
-                                example: "53.10A"
-                                description: >-
-                                  Activité principale de l'établissement selon la nomenclature NAF 2025
-                                  (source : base SIRENE). Champ temporaire, supprimé à compter du 1er janvier 2027.
-                              adresse:
-                                type: string
-                                example: >-
-                                  19 RUE DE LA POSTE 31700 CORNEBARRIEU
-                                description: >-
-                                  Champ construit depuis les champs d'adresse de la
-                                  base SIRENE : *complement adresse + numéro voie +
-                                  indice repetition + type voie + libelle voie +
-                                  distribution spéciale + (code postal + libelle
-                                  commune | cedex + libelle cedex) + libelle commune
-                                  étranger + libelle pays étranger*
-                              ancien_siege:
-                                type: boolean
-                                example: false
-                                description: >-
-                                  L'établissement était le siège de
-                                  l'unité légale (source : base SIRENE).
-                              annee_tranche_effectif_salarie:
-                                type: string
-                                nullable: true
-                                example: "2020"
-                                description: >-
-                                  Année de validité de la tranche d'effectif salarié de
-                                  l'établissement (source : base SIRENE).
-                              caractere_employeur:
-                                type: string
-                                example: "O"
-                                description: >-
-                                  Caractère employeur de l'établissement (source : base SIRENE).
-                              code_postal:
-                                type: string
-                                nullable: true
-                                pattern: >-
-                                  ^((0[1-9])|([1-8][0-9])|(9[0-8])|(2A)|(2B))[0-9]{3}$
-                                example: "75015"
-                                description: >-
-                                  Le code postal de l'adresse de l'établissement
-                                  (source : base SIRENE).
-                              commune:
-                                type: string
-                                example: "31150"
-                                description: >-
-                                  Le code géographique de la commune de localisation de
-                                  l'établissement, hors adresse à l'étranger (source :
-                                  base SIRENE).
-                              date_creation:
-                                type: string
-                                nullable: true
-                                format: date
-                                description: >-
-                                  Date de création de l'établissement (source : base
-                                  SIRENE).
-                              date_debut_activite:
-                                type: string
-                                format: date
-                                nullable: true
-                                example: "2014-04-29"
-                                description: >-
-                                  Date de début d'une période de l'historique d'un
-                                  établissement (source : base SIRENE).
-                              date_fermeture:
-                                type: string
-                                nullable: true
-                                format: date
-                                description: >-
-                                  Date de fermeture de l'établissement (source : base
-                                  historique SIRENE).
-                              epci:
-                                type: string
-                                nullable: true
-                                example: "200058519"
-                                description: >-
-                                  Numéro siren de l'EPCI.
-                              est_siege:
-                                type: boolean
-                                example: false
-                                description: >-
-                                  L'établissement est le siège de l'unité
-                                  légale.
-                              etat_administratif:
-                                type: string
-                                example: "A"
-                                description: >-
-                                  État administratif de l'établissement (A : Actif, F :
-                                  Fermé) (source : base SIRENE).
-                              geo_id:
-                                nullable: true
-                                type: string
-                                example: "31150_0157_00019"
-                                description: >-
-                                  Identifiant géographique de l'adresse de
-                                  l'établissement (source : base SIRENE géocodée par
-                                  data.gouv. Cet identifiant est présent uniquement si
-                                  la géolocalisation est issue de data.gouv).
-                              latitude:
-                                type: string
-                                example: "48.83002"
-                                description: >-
-                                  Latitude de l'établissement (source : la majorité des
-                                  siret utilisent le géocodage provenant de la base
-                                  SIRENE géocodée par data.gouv, à l'exception de ceux
-                                  modifiés après le début du mois en cours, pour lesquels
-                                  la géolocalisation est directement extraite de
-                                  la base SIRENE).
-                              libelle_commune:
-                                type: string
-                                example: "PARIS 15"
-                                description: >-
-                                  Libellé de la commune (source : base SIRENE).
-                              liste_enseignes:
-                                type: array
-                                nullable: true
-                                items:
-                                  type: string
-                                example: [ "LA POSTE" ]
-                                description: >-
-                                  Liste des enseignes de l'établissement (source : base
-                                  SIRENE).
-                              liste_finess:
-                                type: array
-                                nullable: true
-                                description: >-
-                                  Liste des identifiants FINESS Géographiques de l'établissement
-                                  (source : Ministère des Solidarités et de la Santé ).
-                                items:
-                                  type: string
-                                  nullable: true
-                                example: [ "950000364" ]
-                              liste_id_bio:
-                                type: array
-                                description: >-
-                                  Liste des identifiants bio de l'établissement
-                                  (source : Agence Bio).
-                                items:
-                                  type: string
-                                example: ["0923"]
-                              liste_idcc:
-                                type: array
-                                description: >-
-                                  Liste des conventions collectives de l'établissement
-                                  (source : Ministère du travail).
-                                items:
-                                  type: string
-                              liste_finess_juridique:
-                                type: array
-                                description: >-
-                                  Liste des identifiants FINESS Juridiques de l'entreprise
-                                  et de ses établissements.
-                                  (source : Ministère des Solidarités et de la Santé ).
-                                items:
-                                  type: string
-                              liste_id_organisme_formation:
-                                type: array
-                                items:
-                                  type: string
-                                description: >-
-                                  Liste des numéro de déclaration d'activité des
-                                  établissement organismes de formation
-                                  (source : Ministère du Travail).
-                                example: [ "0923" ]
-                              liste_rge:
-                                type: array
-                                items:
-                                  type: string
-                                description: >-
-                                  Liste des identifiants RGE de l'établissement
-                                  (source : ADEME).
-                                example: [ "4131D111", "7122D111" ]
-                              liste_uai:
-                                type: array
-                                items:
-                                  type: string
-                                description: >-
-                                  Liste des identifiants UAI de l'établissements
-                                  (source : Ministère de l'enseignement supérieur et
-                                  de la recherche).
-                                example: [ "0170100S" ]
-                              longitude:
-                                type: string
-                                example: "2.275688"
-                                description: >-
-                                  Longitude de l'établissement (source : la majorité des
-                                  siret utilisent le géocodage provenant de la base
-                                  SIRENE géocodée par data.gouv, à l'exception de ceux
-                                  modifiés après le début du mois en cours, pour
-                                  lesquels la géolocalisation est directement extraite de
-                                  la base SIRENE).
-                              nom_commercial:
-                                type: string
-                                nullable: true
-                                example: null
-                                description: >-
-                                  Dénomination usuelle de l'établissement (source :
-                                  base SIRENE).
-                              region:
-                                type: string
-                                nullable: true
-                                example: "11"
-                                description: >-
-                                  Région de l'établissement (source :
-                                  base SIRENE).
-                              siret:
-                                type: string
-                                example: "35600000000048"
-                                description: le numéro unique de l'établissement.
-                              statut_diffusion_etablissement:
-                                type: string
-                                example: "O"
-                                description: >-
-                                  Statut de diffusion de l'établissement.
-                                  Toutes les établissements diffusibles ont le statut de
-                                  diffusion à "O". Les établissements ayant fait
-                                  l'objet d'une demande d'opposition ont le statut de
-                                  diffusion à "P" pour diffusion partielle
-                                  (source : base SIRENE).
-                              tranche_effectif_salarie:
-                                type: string
-                                nullable: true
-                                example: "12"
-                                description: >-
-                                  Tranche d'effectif salarié de l'établissement
-                                  (source : base SIRENE).
-                        dirigeants:
-                          type: array
-                          items:
-                            oneOf:
-                              - $ref: '#/components/schemas/dirigeant_pp'
-                              - $ref: '#/components/schemas/dirigeant_pm'
-                        finances:
-                          type: object
-                          $ref: >-
-                            #/components/schemas/finances
-                        complements:
-                          type: object
-                          properties:
-                            collectivite_territoriale:
-                              type: object
-                              $ref: >-
-                                #/components/schemas/collectivite_territoriale
-                            convention_collective_renseignee:
-                              type: boolean
-                              description: >-
-                                Indique si au moins un établissement a une
-                                convention collective renseignée
-                            liste_idcc:
-                              type: array
-                              description: >-
-                                Liste des conventions collectives de l'unité légale
-                                (source : Ministère du travail).
-                              items:
-                                  type: string
-                            liste_finess_juridique:
-                              type: array
-                              description: >-
-                                Liste des identifiants FINESS Juridiques de l'entreprise
-                                et de ses établissements.
-                                (source : Ministère des Solidarités et de la Santé ).
-                              items:
-                                  type: string
-                            egapro_renseignee:
-                              type: boolean
-                              description: >-
-                                Indique si au moins un établissement a un
-                                indice égalité professionnel H/F renseigné
-                            est_achats_responsables:
-                              type: boolean
-                              description: >-
-                                Indique si l'entreprise est labelisée
-                                Relations fournisseurs et achats responsables (RFAR)
-                            est_alim_confiance:
-                              type: boolean
-                              description: >-
-                                Indique si l'entreprise a au moins un établissement avec un
-                                résultat de contrôle sanitaire Alim'Confiance.
-                            est_association:
-                              type: boolean
-                              example: false
-                              description: >-
-                                Association (source : INSEE)
-                            est_bio:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant au moins un établissement certifié bio
-                                (source: Agence Bio)
-                            est_entrepreneur_individuel:
-                              type: boolean
-                              description: Entreprise individuelle
-                              example: false
-                            est_entrepreneur_spectacle:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant une licence d'entrepreneur du
-                                spectacle (source: Ministère de la Culture)
-                              example: false
-                            est_ess:
-                              type: boolean
-                              description: >-
-                                Entreprise d'économie sociale et solidaire
-                                (source: ESS France et INSEE)
-                              example: false
-                            est_finess:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant au moins un établissement FINESS
-                                (source : Ministère des Solidarités et de la Santé)
-                              example: false
-                            est_organisme_formation:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant au moins un établissement organisme de
-                                formation (source: Ministère du Travail)
-                            est_patrimoine_vivant:
-                              type: boolean
-                              description: >-
-                                Entreprise du Patrimoine Vivant (EPV)
-                            est_qualiopi:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant une certification de la
-                                marque « Qualiopi » (source: Ministère du Travail)
-                            liste_id_organisme_formation:
-                              type: array
-                              description: >-
-                                Liste des numéro de déclaration d’activité des
-                                établissement organismes de formation
-                                (source : Ministère du Travail).
-                              items:
-                                type: string
-                              example: [ "0923" ]
-                            est_rge:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant au moins un établissement RGE
-                                (source : ADEME)
-                              example: false
-                            est_service_public:
-                              type: boolean
-                              description: >-
-                                Uniquement les structures reconnues comme administration.
-
-                                Attention : Ce champ se base sur cette liste
-                                <a href=https://www.data.gouv.fr/fr/datasets/liste-des-administrations-francaises/ici</a>.
-
-                                Ce champ n'est pas exhaustif et peut retourner des faux positifs.
-                              example: false
-                            est_l100_3:
-                              type: boolean
-                              description: >-
-                                Uniquement les structures reconnues comme administration au sens de l'artcile L.100-3.
-
-                                Attention : Ce champ se base sur cette liste
-                                <a href=https://www.data.gouv.fr/fr/datasets/liste-des-administrations-francaises/ici</a>.
-
-                                Ce champ n'est pas exhaustif et peut retourner des faux positifs.
-                            est_societe_mission:
-                              type: boolean
-                              example: false
-                              description: >-
-                                Société qui appartient au champ des sociétés à
-                                mission.
-                            est_uai:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant au moins un établissement UAI
-                                (source : Ministère de l'enseignement supérieur et de
-                                la recherche)
-                              example: false
-                            bilan_ges_renseigne:
-                              type: boolean
-                              description: >-
-                                Entreprise ayant un bilan ges publié
-                                (source : ADEME)
-                              example: false
-                            identifiant_association:
-                              type: string
-                              nullable: true
-                              example: null
-                              description: >-
-                                Numéro au Répertoire National des Associations (RNA)
-                                (source : base SIRENE)
-                            statut_bio:
-                              type: boolean
-                              description: >-
-                                Statut des établissements ayant fait une demande de
-                                certification bio
-                                (source: Agence Bio)
-                            statut_entrepreneur_spectacle:
-                              type: string
-                              nullable: true
-                              description: >-
-                                Statut des établissements ayant fait une demande de
-                                licence d'entrepreneur du spectacle
-                                (source: Ministère de la Culture)
-                            type_siae:
-                              type: string
-                              nullable: true
-                              description: >-
-                                Type de structure de l'inclusion
-                                (source: Marché de l'Inclusion)
-                  total_results:
-                    type: integer
-                  page:
-                    type: integer
-                    default: 1
-                  per_page:
-                    type: integer
-                    default: 10
-                    description: Nombre de résultats par page, limité à 25.
-                  total_pages:
-                    type: integer
-                    example: 1000
+                $ref: '#/components/schemas/payload'
         '400':
           description: Requête incorrecte.
           content:
@@ -2688,23 +963,23 @@ components:
     collectivite_territoriale:
       type: object
       properties:
-        code_insee:
-          type: string
-          description: Code INSEE de la collectivité territoriale
-          example: '01'
         code:
           type: string
           description: Code de la collectivité territoriale
           example: '01'
-        niveau:
+        code_insee:
           type: string
-          description: Niveau de la collectivité territoriale
-          example: département
+          description: Code INSEE de la collectivité territoriale
+          example: '01'
         elus:
           type: array
           items:
             oneOf:
               - $ref: '#/components/schemas/elu'
+        niveau:
+          type: string
+          description: Niveau de la collectivité territoriale
+          example: département
     elu:
       type: object
       properties:
@@ -2726,6 +1001,931 @@ components:
           type: string
           description: Sexe de l'élu
           example: "F"
+
+    # Champs affichés pour les établissements
+    # Certains champs sont en communs avec établissements
+    # et doivent être maintenus dans les deux components
+    etablissement:
+      type: object
+      properties:
+        activite_principale:
+          type: string
+          example: "53.10Z"
+          description: >-
+            Activité principale de l'établissement (source :
+            base SIRENE).
+        activite_principale_naf25:
+          type: string
+          example: "53.10A"
+          description: >-
+            Activité principale de l'établissement selon la nomenclature NAF 2025
+            (source : base SIRENE). Champ temporaire, supprimé à compter du 1er janvier 2027.
+        ancien_siege:
+          type: boolean
+          example: false
+          description: >-
+            L'établissement était le siège de
+            l'unité légale (source : base SIRENE).
+        annee_tranche_effectif_salarie:
+          type: string
+          nullable: true
+          example: "2020"
+          description: >-
+            Année de validité de la tranche d'effectif salarié de
+            l'établissement (source : base SIRENE).
+        adresse:
+          type: string
+          example: >-
+            19 RUE DE LA POSTE 31700 CORNEBARRIEU
+          description: >-
+            Champ construit depuis les champs d'adresse de la
+            base SIRENE : *complement adresse + numéro voie +
+            indice repetition + type voie + libelle voie +
+            distribution spéciale + (code postal + libelle
+            commune | cedex + libelle cedex) + libelle commune
+            étranger + libelle pays étranger*
+        caractere_employeur:
+          type: string
+          example: "O"
+          description: >-
+            Caractère employeur de l'établissement (source : base SIRENE).
+        code_postal:
+          type: string
+          nullable: true
+          pattern: >-
+            ^((0[1-9])|([1-8][0-9])|(9[0-8])|(2A)|(2B))[0-9]{3}$
+          example: "75015"
+          description: >-
+            Le code postal de l'adresse de l'établissement
+            (source : base SIRENE).
+        commune:
+          type: string
+          example: "75115"
+          description: >-
+            Le code géographique de la commune de localisation de
+            l'établissement, hors adresse à l'étranger (source :
+            base SIRENE).
+        date_creation:
+          type: string
+          nullable: true
+          format: date
+          description: >-
+            Date de création de l'établissement (source : base
+            SIRENE).
+        date_debut_activite:
+          type: string
+          format: date
+          nullable: true
+          example: "2014-04-29"
+          description: >-
+            Date de début d'une période de l'historique d'un
+            établissement (source : base SIRENE).
+        date_fermeture:
+          type: string
+          nullable: true
+          format: date
+          description: >-
+            Date de fermeture de l'établissement (source : base
+            historique SIRENE).
+        epci:
+          type: string
+          nullable: true
+          example: "200058519"
+          description: >-
+            Numéro siren de l'EPCI.
+        est_siege:
+          type: boolean
+          example: false
+          description: >-
+            L'établissement est le siège de l'unité
+            légale.
+        etat_administratif:
+          type: string
+          example: "A"
+          description: >-
+            État administratif de l'établissement (A : Actif, F :
+            Fermé) (source : base SIRENE).
+        geo_id:
+          nullable: true
+          type: string
+          example: "31150_0157_00019"
+          description: >-
+            Identifiant géographique de l'adresse de
+            l'établissement (source : base SIRENE géocodée par
+            data.gouv. Cet identifiant est présent uniquement si
+            la géolocalisation est issue de data.gouv).
+        latitude:
+          type: string
+          example: "48.83002"
+          description: >-
+            Latitude de l'établissement (source : la majorité des
+            siret utilisent le géocodage provenant de la base
+            SIRENE géocodée par data.gouv, à l'exception de ceux
+            modifiés après le début du mois en cours, pour lesquels
+            la géolocalisation est directement extraite de
+            la base SIRENE).
+        libelle_commune:
+          type: string
+          example: "PARIS 15"
+          description: >-
+            Libellé de la commune (source : base SIRENE).
+        liste_enseignes:
+          type: array
+          nullable: true
+          items:
+            type: string
+          example: [ "LA POSTE" ]
+          description: >-
+            Liste des enseignes de l'établissement (source : base
+            SIRENE).
+        liste_finess:
+          type: array
+          nullable: true
+          description: >-
+            Liste des identifiants FINESS Géographiques de l'établissement
+            (source : Ministère des Solidarités et de la Santé ).
+          items:
+            type: string
+            nullable: true
+          example: [ "950000364" ]
+        liste_id_bio:
+          type: array
+          description: >-
+            Liste des identifiants bio de l'établissement
+            (source : Agence Bio).
+          items:
+            type: string
+          example: ["0923"]
+        liste_idcc:
+          type: array
+          description: >-
+            Liste des conventions collectives de l'établissement
+            (source : Ministère du travail).
+          items:
+            type: string
+          example: [ "0923" ]
+        liste_id_organisme_formation:
+          type: array
+          items:
+            type: string
+          description: >-
+            Liste des numéro de déclaration d'activité des
+            établissement organismes de formation
+            (source : Ministère du Travail).
+        liste_rge:
+          type: array
+          items:
+            type: string
+          description: >-
+            Liste des identifiants RGE de l'établissement
+            (source : ADEME).
+          example: [ "4131D111", "7122D111" ]
+        liste_uai:
+          type: array
+          items:
+            type: string
+          description: >-
+            Liste des identifiants UAI de l'établissements
+            (source : Ministère de l'enseignement supérieur et
+            de la recherche).
+          example: [ "0170100S" ]
+        longitude:
+          type: string
+          example: "2.275688"
+          description: >-
+            Longitude de l'établissement (source : la majorité des
+            siret utilisent le géocodage provenant de la base
+            SIRENE géocodée par data.gouv, à l'exception de ceux
+            modifiés après le début du mois en cours, pour
+            lesquels la géolocalisation est directement extraite
+            de la base SIRENE).
+        nom_commercial:
+          type: string
+          nullable: true
+          example: null
+          description: >-
+            Dénomination usuelle de l'établissement (source :
+            base SIRENE).
+        region:
+          type: string
+          nullable: true
+          example: "11"
+          description: >-
+            Région de l'établissement (source :
+            base SIRENE).
+        siret:
+          type: string
+          example: "35600000000048"
+          description: le numéro unique de l'établissement.
+        statut_diffusion_etablissement:
+          type: string
+          example: "O"
+          description: >-
+            Statut de diffusion de l'établissement.
+            Toutes les établissements diffusibles ont le statut de
+            diffusion à "O". Les établissements ayant fait
+            l'objet d'une demande d'opposition ont le statut de
+            diffusion à "P" pour diffusion partielle
+            (source : base SIRENE).
+        tranche_effectif_salarie:
+          type: string
+          nullable: true
+          example: "12"
+          description: >-
+            Tranche d'effectif salarié de l'établissement
+            (source : base SIRENE).
+
+    # Champs affichés uniquement pour le siège
+    # Certains champs sont en communs avec établissements
+    # et doivent être maintenus dans les deux components
+    siege:
+      type: object
+      properties:
+        activite_principale:
+          type: string
+          example: "53.10Z"
+          description: >-
+            Activité principale de l'établissement (source :
+            base SIRENE).
+        activite_principale_naf25:
+          type: string
+          example: "53.10A"
+          description: >-
+            Activité principale de l'établissement selon la nomenclature NAF 2025
+            (source : base SIRENE). Champ temporaire, supprimé à compter du 1er janvier 2027.
+        activite_principale_registre_metier:
+          type: string
+          nullable: true
+          example: null
+          description: >-
+            Activité principale de l'établissement au Registre
+            des Métiers (source : base SIRENE).
+        annee_tranche_effectif_salarie:
+          type: string
+          nullable: true
+          example: "2020"
+          description: >-
+            Année de validité de la tranche d'effectif salarié de
+            l'établissement (source : base SIRENE).
+        adresse:
+          type: string
+          example: >-
+            19 RUE DE LA POSTE 31700 CORNEBARRIEU
+          description: >-
+            Champ construit depuis les champs d'adresse de la
+            base SIRENE : *complement adresse + numéro voie +
+            indice repetition + type voie + libelle voie +
+            distribution spéciale + (code postal + libelle
+            commune | cedex + libelle cedex) + libelle commune
+            étranger + libelle pays étranger*
+        caractere_employeur:
+          type: string
+          example: "O"
+          description: >-
+            Caractère employeur de l'établissement (source : base SIRENE).
+        cedex:
+          type: string
+          nullable: true
+          example: null
+          description: >-
+            Code cedex de l'établissement. Cette variable
+            facultative est un élément constitutif de l'adresse.
+            (source : base SIRENE).
+        code_pays_etranger:
+          type: string
+          nullable: true
+          example: null
+          description: >-
+            Code pays de l'adresse d'un établissement situé à
+            l'étranger (source : base SIRENE).
+        code_postal:
+          type: string
+          nullable: true
+          pattern: >-
+            ^((0[1-9])|([1-8][0-9])|(9[0-8])|(2A)|(2B))[0-9]{3}$
+          example: "75015"
+          description: >-
+            Le code postal de l'adresse de l'établissement
+            (source : base SIRENE).
+        commune:
+          type: string
+          example: "75115"
+          description: >-
+            Le code géographique de la commune de localisation de
+            l'établissement, hors adresse à l'étranger (source :
+            base SIRENE).
+        complement_adresse:
+          type: string
+          nullable: true
+          example: "DIRECTION GENERALE DE LA POSTE"
+          description: >-
+            Le code géographique de la commune de localisation de
+            l'établissement, hors adresse à l'étranger (source :
+            base SIRENE).
+        coordonnees:
+          type: string
+          nullable: true
+          example: "43.292154,5.359134"
+          description: >-
+            Coordonnées GPS de l'établissement (latitude, longitude).
+        date_creation:
+          type: string
+          nullable: true
+          format: date
+          description: >-
+            Date de création de l'établissement (source : base
+            SIRENE).
+        date_debut_activite:
+          type: string
+          format: date
+          nullable: true
+          example: "2014-04-29"
+          description: >-
+            Date de début d'une période de l'historique d'un
+            établissement (source : base SIRENE).
+        date_fermeture:
+          type: string
+          nullable: true
+          format: date
+          description: >-
+            Date de fermeture de l'établissement (source : base
+            historique SIRENE).
+        date_mise_a_jour:
+          type: string
+          format: date-time
+          nullable: true
+          example: "2023-09-21T03:34:50"
+          description: >-
+            Date du dernier traitement de l'établissement dans le
+            répertoire Sirene (source : base SIRENE). Obsolète.
+        date_mise_a_jour_insee:
+          type: string
+          format: date-time
+          nullable: true
+          example: "2023-09-21T03:34:50"
+          description: >-
+            Date du dernier traitement de l'établissement dans le
+            répertoire Sirene (source : base SIRENE).
+        departement:
+          type: string
+          nullable: true
+          pattern: \b([013-8]\d?|2[aAbB1-9]?|9[0-59]?|97[12346])\b
+          example: "75"
+          description: >-
+            Code département de l'établissement (source : base
+            SIRENE).
+        distribution_speciale:
+          type: string
+          nullable: true
+          example: null
+          description: >-
+            Distribution spéciale de l'établissement (source :
+            base SIRENE).
+        epci:
+          type: string
+          nullable: true
+          example: "200058519"
+          description: >-
+            Numéro siren de l'EPCI.
+        est_siege:
+          type: boolean
+          example: false
+          description: >-
+            L'établissement est le siège de l'unité
+            légale.
+        etat_administratif:
+          type: string
+          example: "A"
+          description: >-
+            État administratif de l'établissement (A : Actif, F :
+            Fermé) (source : base SIRENE).
+        geo_adresse:
+          nullable: true
+          type: string
+          example: "58 Boulevard charles livon 13007 Marseille"
+          description: >-
+            Adresse de l'établissement (source : base SIRENE géocodée par
+            data.gouv. Cet identifiant est présent uniquement si la
+            géolocalisation est issue de data.gouv).
+        geo_id:
+          nullable: true
+          type: string
+          example: "31150_0157_00019"
+          description: >-
+            Identifiant géographique de l'adresse de
+            l'établissement (source : base SIRENE géocodée par
+            data.gouv. Cet identifiant est présent uniquement si
+            la géolocalisation est issue de data.gouv).
+        indice_repetition:
+          nullable: true
+          type: string
+          example: null
+          description: >-
+            Indice de répétition du numéro dans la voie (B pour
+            Bis, T pour TER, lettres ou chiffres pour identifier
+            différents bâtiments à une même adresse...) (source :
+            base SIRENE).
+        latitude:
+          type: string
+          example: "48.83002"
+          description: >-
+            Latitude de l'établissement (source : la majorité des
+            siret utilisent le géocodage provenant de la base
+            SIRENE géocodée par data.gouv, à l'exception de ceux
+            modifiés après le début du mois en cours, pour lesquels
+            la géolocalisation est directement extraite de
+            la base SIRENE).
+        libelle_cedex:
+          type: string
+          nullable: true
+          description: >-
+            Libellé associé au code cedex (source : base SIRENE).
+          example: null
+        libelle_commune:
+          type: string
+          example: "PARIS 15"
+          description: >-
+            Libellé de la commune (source : base SIRENE).
+        libelle_commune_etranger:
+          type: string
+          nullable: true
+          example: null
+          description: >-
+            Libellé de la commune pour un établissement situé à
+            l'étranger (source : base SIRENE).
+        libelle_pays_etranger:
+          type: string
+          nullable: true
+          example: null
+          description: >-
+            Libellé du pays pour un établissement situé à
+            l'étranger (source : base SIRENE).
+        libelle_voie:
+          type: string
+          example: "DU COLONEL PIERRE AVIA"
+          description: >-
+            Libellé de la voie (source : base SIRENE).
+        liste_enseignes:
+          type: array
+          nullable: true
+          items:
+            type: string
+          example: [ "LA POSTE" ]
+          description: >-
+            Liste des enseignes de l'établissement (source : base
+            SIRENE).
+        liste_finess:
+          type: array
+          nullable: true
+          description: >-
+            Liste des identifiants FINESS Géographiques de l'établissement
+            (source : Ministère des Solidarités et de la Santé ).
+          items:
+            type: string
+            nullable: true
+          example: [ "950000364" ]
+        liste_id_bio:
+          type: array
+          description: >-
+            Liste des identifiants bio de l'établissement
+            (source : Agence Bio).
+          items:
+            type: string
+          example: ["0923"]
+        liste_idcc:
+          type: array
+          description: >-
+            Liste des conventions collectives de l'établissement
+            (source : Ministère du travail).
+          items:
+            type: string
+          example: [ "0923" ]
+        liste_id_organisme_formation:
+          type: array
+          items:
+            type: string
+          description: >-
+            Liste des numéro de déclaration d'activité des
+            établissement organismes de formation
+            (source : Ministère du Travail).
+        liste_rge:
+          type: array
+          items:
+            type: string
+          description: >-
+            Liste des identifiants RGE de l'établissement
+            (source : ADEME).
+          example: [ "4131D111", "7122D111" ]
+        liste_uai:
+          type: array
+          items:
+            type: string
+          description: >-
+            Liste des identifiants UAI de l'établissements
+            (source : Ministère de l'enseignement supérieur et
+            de la recherche).
+          example: [ "0170100S" ]
+        longitude:
+          type: string
+          example: "2.275688"
+          description: >-
+            Longitude de l'établissement (source : la majorité des
+            siret utilisent le géocodage provenant de la base
+            SIRENE géocodée par data.gouv, à l'exception de ceux
+            modifiés après le début du mois en cours, pour
+            lesquels la géolocalisation est directement extraite
+            de la base SIRENE).
+        nom_commercial:
+          type: string
+          nullable: true
+          example: null
+          description: >-
+            Dénomination usuelle de l'établissement (source :
+            base SIRENE).
+        numero_voie:
+          type: string
+          example: "9"
+          description: >-
+            Numéro dans la voie (source : base SIRENE).
+        region:
+          type: string
+          nullable: true
+          example: "11"
+          description: >-
+            Région de l'établissement (source :
+            base SIRENE).
+        siret:
+          type: string
+          example: "35600000000048"
+          description: le numéro unique de l'établissement.
+        statut_diffusion_etablissement:
+          type: string
+          example: "O"
+          description: >-
+            Statut de diffusion de l'établissement.
+            Toutes les établissements diffusibles ont le statut de
+            diffusion à "O". Les établissements ayant fait
+            l'objet d'une demande d'opposition ont le statut de
+            diffusion à "P" pour diffusion partielle
+            (source : base SIRENE).
+        tranche_effectif_salarie:
+          type: string
+          nullable: true
+          example: "12"
+          description: >-
+            Tranche d'effectif salarié de l'établissement
+            (source : base SIRENE).
+        type_voie:
+          type: string
+          example: "RUE"
+          description: >-
+            Type de voie de l'adresse (source : base SIRENE).
+
+    # Content of each result item
+    result:
+      type: object
+      properties:
+        siren:
+          type: string
+          example: "356000000"
+          description: le numéro unique de l'entreprise
+        nom_complet:
+          type: string
+          description: >-
+            Champ construit depuis les champs de dénomination :
+            dénomination de l'unité légale | Nom et prénom | Nom inconnu
+            (dénomination usuelle : Construite en priorité à partir de
+            la dénomination usuelle de l'établissement siège.
+            Si cette dernière n'existe pas, elle est construite à
+            partir des trois champs de dénomination usuelle de l'unité
+            légale. source : base SIRENE) (sigle de l'unité légale)
+          example: "la poste"
+        nom_raison_sociale:
+          type: string
+          example: "LA POSTE"
+          description: >-
+            La raison sociale pour les personnes morales (source :
+            base SIRENE).
+        sigle:
+          type: string
+          nullable: true
+          example: null
+          description: >-
+            Forme réduite de la raison sociale ou de la dénomination
+            d'une personne morale ou d'un organisme public (source :
+            base SIRENE).
+        nombre_etablissements:
+          type: integer
+          title: Nombre des établissements de l'unité légale
+          example: 12734
+        nombre_etablissements_ouverts:
+          type: integer
+          title: Nombre des établissements ouverts de l'unité légale
+          example: 9524
+        siege:
+          $ref: >-
+            #/components/schemas/siege
+        activite_principale:
+          type: string
+          example: "53.10Z"
+          description: >-
+            Code de l'activité principale exercée (APE) par l'unité
+            légale (source : base SIRENE).
+        activite_principale_naf25:
+          type: string
+          example: "53.10A"
+          description: >-
+            Activité principale de l'unité légale selon la nomenclature NAF 2025
+            (source : base SIRENE). Champ temporaire, supprimé à compter du 1er janvier 2027.
+        categorie_entreprise:
+          type: string
+          example: "GE"
+          description: >-
+            Catégorie d'entreprise de l'unité légale (source : base
+            SIRENE).
+        caractere_employeur:
+          type: string
+          example: "O"
+          description: >-
+            Caractère employeur de l'unité légale (source : base
+            SIRENE).
+        annee_categorie_entreprise:
+          type: string
+          example: "2020"
+          description: >-
+            Année de validité correspondant à la catégorie
+            d'entreprise diffusée (source : base
+            SIRENE).
+        date_creation:
+          type: string
+          format: date
+          example: "1991-01-01"
+          description: >-
+            Date de création de l'unité légale (source : base SIRENE).
+        date_fermeture:
+          type: string
+          format: date
+          description: >-
+            Date de fermeture de l'unité légale (source : base
+            historique SIRENE).
+        date_mise_a_jour:
+          type: string
+          format: date-time
+          example: "2023-09-21T03:34:50"
+          description: >-
+            Date de la dernière modification d'une variable de niveau
+            unité légale, qu'elle soit historisée ou non (source :
+            base SIRENE).
+        date_mise_a_jour_insee:
+          type: string
+          nullable: true
+          format: date-time
+          example: "2023-09-21T03:34:50"
+          description: >-
+            Date de la dernière mise à jour des données INSEE pour
+            cette unité légale.
+        date_mise_a_jour_rne:
+          type: string
+          nullable: true
+          format: date-time
+          example: "2023-09-20T02:15:30"
+          description: >-
+            Date de la dernière mise à jour des données RNCS pour
+            cette unité légale.
+        dirigeants:
+          type: array
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/dirigeant_pp'
+              - $ref: '#/components/schemas/dirigeant_pm'
+        etat_administratif:
+          type: string
+          example: "A"
+          description: >-
+            État administratif de l'unité légale (source : base SIRENE).
+        nature_juridique:
+          type: string
+          example: "5510"
+          description: >-
+            Catégorie juridique de l'unité légale (source : base SIRENE).
+        section_activite_principale:
+          type: string
+          example: "H"
+          description: Calculée à partir de l'activité principale.
+        tranche_effectif_salarie:
+          type: string
+          example: "53"
+          description: >-
+            Tranche d'effectif salarié de l'unité légale (source :
+            base SIRENE).
+        annee_tranche_effectif_salarie:
+          type: string
+          example: "2020"
+          description: >-
+            Année de validité de la tranche d'effectif salarié de
+            l'unité légale (source : base SIRENE).
+        statut_diffusion:
+          type: string
+          example: "O"
+          description: >-
+            Statut de diffusion de l'unité légale.
+            Toutes les unités légales diffusibles ont le statut de
+            diffusion à "O". Les unités légales ayant fait l'objet d'une
+            demande d'opposition ont le statut de diffusion à "P" pour
+            diffusion partielle (source : base SIRENE).
+        matching_etablissements:
+          type: array
+          items:
+            $ref: '#/components/schemas/etablissement'
+        finances:
+          $ref: '#/components/schemas/finances'
+        complements:
+          type: object
+          properties:
+            collectivite_territoriale:
+              $ref: '#/components/schemas/collectivite_territoriale'
+            convention_collective_renseignee:
+              type: boolean
+              description: >-
+                Indique si au moins un établissement a une
+                convention collective renseignée
+            liste_idcc:
+              type: array
+              description: >-
+                Liste des conventions collectives de l'unité légale
+                (source : Ministère du travail)
+              items:
+                type: string
+            liste_finess_juridique:
+              type: array
+              description: >-
+                Liste des identifiants FINESS Juridiques de l'entreprise
+                et de ses établissements.
+                (source : Ministère des Solidarités et de la Santé ).
+              items:
+                type: string
+            egapro_renseignee:
+              type: boolean
+              description: >-
+                Indique si au moins un établissement a un
+                indice égalité professionnel H/F renseigné
+            est_achats_responsables:
+              type: boolean
+              description: >-
+                Indique si l'entreprise est labelisée
+                Relations fournisseurs et achats responsables (RFAR)
+            est_alim_confiance:
+              type: boolean
+              description: >-
+                Indique si l'entreprise a au moins un établissement avec un
+                résultat de contrôle sanitaire Alim'Confiance.
+            est_association:
+              type: boolean
+              example: false
+              description: >-
+                Association (source : INSEE)
+            est_bio:
+              type: boolean
+              description: >-
+                Entreprise ayant au moins un établissement certifié bio
+                (source: Agence Bio)
+            est_entrepreneur_individuel:
+              type: boolean
+              description: Entreprise individuelle
+              example: false
+            est_entrepreneur_spectacle:
+              type: boolean
+              description: >-
+                Entreprise ayant une licence d'entrepreneur du
+                spectacle (source : Ministère de la Culture)
+              example: false
+            est_ess:
+              type: boolean
+              description: >-
+                Entreprise d'économie sociale et solidaire
+                (source : ESS France et INSEE)
+              example: false
+            est_finess:
+              type: boolean
+              description: >-
+                Entreprise ayant au moins un établissement FINESS
+                (source : Ministère des Solidarités et de la Santé)
+              example: false
+            est_organisme_formation:
+              type: boolean
+              description: >-
+                Entreprise ayant au moins un établissement organisme de
+                formation (source : Ministère du Travail)
+            est_qualiopi:
+              type: boolean
+              description: >-
+                Entreprise ayant une certification de la
+                marque « Qualiopi » (source : Ministère du Travail)
+            liste_id_organisme_formation:
+              type: array
+              description: >-
+                Liste des numéro de déclaration d’activité des
+                établissement organismes de formation
+                (source : Ministère du Travail).
+              items:
+                type: string
+              example: [ "7423P001123" ]
+            est_rge:
+              type: boolean
+              description: >-
+                Entreprise ayant au moins un établissement RGE
+                (source : ADEME)
+              example: false
+            est_service_public:
+              type: boolean
+              description: >-
+                Uniquement les structures reconnues comme administration.
+
+                Attention : Ce champ se base sur cette liste
+                <a href=https://www.data.gouv.fr/fr/datasets/liste-des-administrations-francaises/ici</a>.
+
+                Ce champ n'est pas exhaustif et peut retourner des faux positifs.
+              example: false
+            est_l100_3:
+              type: boolean
+              description: >-
+                Uniquement les structures reconnues comme administration au sens de l'artcile L.100-3.
+
+                Attention : Ce champ se base sur cette liste
+                <a href=https://www.data.gouv.fr/fr/datasets/liste-des-administrations-francaises/ici</a>.
+
+                Ce champ n'est pas exhaustif et peut retourner des faux positifs.
+              example: false
+            est_siae:
+              type: boolean
+              description: >-
+                Structure d'insertion par l'activité économique
+                (source : Marché de l'Inclusion)
+              example: false
+            est_societe_mission:
+              type: boolean
+              example: false
+              description: >-
+                Société qui appartient au champ des sociétés à
+                mission.
+            est_uai:
+              type: boolean
+              description: >-
+                Entreprise ayant au moins un établissement UAI
+                (source : Ministère de l'enseignement supérieur et de
+                la recherche)
+              example: false
+            est_patrimoine_vivant:
+              type: boolean
+              description: >-
+                Entreprise du Patrimoine Vivant (EPV)
+            bilan_ges_renseigne:
+              type: boolean
+              description: >-
+                Entreprise ayant un bilan ges publié
+                (source : ADEME)
+              example: false
+            identifiant_association:
+              type: string
+              nullable: true
+              example: null
+              description: >-
+                Numéro au Répertoire National des Associations (RNA)
+                (source : base SIRENE)
+            statut_entrepreneur_spectacle:
+              type: string
+              nullable: true
+              description: >-
+                Statut des établissements ayant fait une demande de
+                licence d'entrepreneur du spectacle
+                (source : Ministère de la Culture)
+            type_siae:
+              type: string
+              nullable: true
+              description: >-
+                Type de structure de l'inclusion
+                (source : Marché de l'Inclusion)
+
+    # Root level of the payload
+    payload:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/result'
+        total_results:
+          type: integer
+        page:
+          type: integer
+          default: 1
+        per_page:
+          type: integer
+          default: 10
+          description: Nombre de résultats par page, limité à 25.
+        total_pages:
+          type: integer
+          example: 1000
 servers:
   - url: https://recherche-entreprises.api.gouv.fr
     description: Serveur de production


### PR DESCRIPTION
* Ajout des paramètres et champs retournés manquants
* Rend la documentation plus facile à maintenir avec les components. Chaque champs est maintenant définit qu'une seule fois ! Avec une seule exception les champs en commun entre `siege` et `etablissement`.
* Tous les champs ont été ordonnés afin de correspondre à l'ordre du payload.
* Corriger des typos

Closes #612 