### PR TITLE
feat(sentry): split staging from prod issues

### DIFF
--- a/app/logging.py
+++ b/app/logging.py
@@ -12,7 +12,7 @@ def setup_logging():
 
 
 def setup_sentry():
-    if settings.env == "prod":
+    if settings.env in ["prod", "staging"]:
         sentry_logging = LoggingIntegration(
             level=logging.INFO,
             event_level=logging.WARNING,
@@ -23,5 +23,6 @@ def setup_sentry():
                 FastApiIntegration(),
                 sentry_logging,
             ],
+            environment="production" if settings.env == "prod" else settings.env,
             traces_sample_rate=0.01,
         )

--- a/app/main.py
+++ b/app/main.py
@@ -43,8 +43,8 @@ def custom_openapi():
 
 app.openapi = custom_openapi
 
-# Sentry Integration and Elastic APM Integration for Production
-if settings.env == "prod":
+# Sentry Integration and Elastic APM Integration for Production and Staging
+if settings.env in ["prod", "staging"]:
     apm_client = make_apm_client(settings.apm_config)
     app.add_middleware(ElasticAPM, client=apm_client)
     setup_sentry()


### PR DESCRIPTION
Related to https://github.com/annuaire-entreprises-data-gouv-fr/infrastructure/pull/732

Currently Sentry mix both production and staging issues which make it hard to monitor their criticity. It is possible to filter on the `server_name` but it is curbersome.
This will allow us to easily filter each environment.