### PR TITLE
fix(search): don't include dirigeants in search when company is ND

### DIFF
--- a/app/elastic/queries/person.py
+++ b/app/elastic/queries/person.py
@@ -151,12 +151,40 @@ def search_person(
         # score to exact
         # matches
         if person_filters or boost_queries:
-            search_options.append(
-                query.Q(
-                    "nested",
-                    path="unite_legale." + person["type_person"],
-                    query=query.Bool(must=person_filters, should=boost_queries),
-                )
+            nested_bool = query.Bool(must=person_filters, should=boost_queries)
+            nested_query = query.Q(
+                "nested",
+                path="unite_legale." + person["type_person"],
+                query=nested_bool,
             )
-    search = search.query("bool", should=search_options)
+
+            # Root-level diffusion gating for dirigeants:
+            # we must not match a document via dirigeants when diffusion is "P".
+            # (Putting this condition inside the nested query would not reliably
+            # match root fields.)
+            if person["type_person"] == "dirigeants_pp":
+                nested_query = query.Q(
+                    "bool",
+                    must=[nested_query],
+                    filter=[
+                        query.Q(
+                            "bool",
+                            must_not=[
+                                query.Q(
+                                    "term",
+                                    **{
+                                        "unite_legale.statut_diffusion_unite_legale": "P"
+                                    },
+                                ),
+                            ],
+                        )
+                    ],
+                )
+
+            search_options.append(nested_query)
+    # When there is already a filter query on the Search (which is the case in
+    # our pipeline), Elasticsearch treats `should` as optional unless
+    # `minimum_should_match` is set. We want a person search to actually require
+    # matching at least one of the nested person clauses.
+    search = search.query("bool", should=search_options, minimum_should_match=1)
     return search

--- a/app/elastic/queries/person.py
+++ b/app/elastic/queries/person.py
@@ -33,6 +33,17 @@ def search_person(
     param_date_max,
     list_persons,
 ):
+    """
+    Build a person search across nested person arrays (e.g. dirigeants, élus).
+
+    Notes:
+    - This function adds a `bool.should` query to the existing Search object.
+      Because our pipeline already adds root-level filters, Elasticsearch would
+      otherwise treat `should` clauses as optional; we explicitly require at
+      least one person clause to match (see `minimum_should_match` below).
+    - For dirigeants specifically, we must avoid matching documents when
+      `statut_diffusion_unite_legale == "P"` (privacy constraint).
+    """
     search_options = []
     for person in list_persons:
         person_filters = []
@@ -151,6 +162,9 @@ def search_person(
         # score to exact
         # matches
         if person_filters or boost_queries:
+            # Nested query matches within the person array items
+            # (`unite_legale.<type_person>`), while keeping the scoring behavior
+            # (boost exact keyword phrase matches).
             nested_bool = query.Bool(must=person_filters, should=boost_queries)
             nested_query = query.Q(
                 "nested",
@@ -158,10 +172,15 @@ def search_person(
                 query=nested_bool,
             )
 
-            # Root-level diffusion gating for dirigeants:
-            # we must not match a document via dirigeants when diffusion is "P".
-            # (Putting this condition inside the nested query would not reliably
-            # match root fields.)
+            # Root-level diffusion gating for dirigeants.
+            #
+            # Why root-level? `statut_diffusion_unite_legale` is a root field on
+            # the document. Putting a root-field constraint *inside* a `nested`
+            # query is not reliable because nested queries run in the nested
+            # document scope.
+            #
+            # Business rule: never match a document via dirigeants when diffusion
+            # is "P".
             if person["type_person"] == "dirigeants_pp":
                 nested_query = query.Q(
                     "bool",
@@ -182,9 +201,10 @@ def search_person(
                 )
 
             search_options.append(nested_query)
-    # When there is already a filter query on the Search (which is the case in
-    # our pipeline), Elasticsearch treats `should` as optional unless
-    # `minimum_should_match` is set. We want a person search to actually require
-    # matching at least one of the nested person clauses.
+    # Elasticsearch detail:
+    # If the surrounding bool query has any `must`/`filter` clauses (true in our
+    # pipeline), `should` clauses become optional unless `minimum_should_match`
+    # is set. For a person search, we want at least one person nested clause to
+    # match, otherwise we'd return documents that only satisfy the other filters.
     search = search.query("bool", should=search_options, minimum_should_match=1)
     return search

--- a/app/elastic/queries/text.py
+++ b/app/elastic/queries/text.py
@@ -244,13 +244,32 @@ def sort_by_size_text_query(terms: str, matching_size: int):
                 {
                     "function_score": {
                         "query": {
-                            "match": {
-                                "unite_legale.liste_dirigeants": {
-                                    "query": terms,
-                                    "operator": "AND",
-                                    "boost": 10,
-                                    "_name": "partial match liste dirigeants",
-                                }
+                            "bool": {
+                                "must": [
+                                    {
+                                        "match": {
+                                            "unite_legale.liste_dirigeants": {
+                                                "query": terms,
+                                                "operator": "AND",
+                                                "boost": 10,
+                                                "_name": "partial match liste dirigeants",
+                                            }
+                                        }
+                                    }
+                                ],
+                                "filter": [
+                                    {
+                                        "bool": {
+                                            "must_not": [
+                                                {
+                                                    "term": {
+                                                        "unite_legale.statut_diffusion_unite_legale": "P"
+                                                    }
+                                                },
+                                            ]
+                                        }
+                                    }
+                                ],
                             }
                         },
                         "field_value_factor": min_multiplier,
@@ -517,13 +536,32 @@ def sort_by_nombre_etablissement_query(terms: str, matching_size: int):
                 {
                     "function_score": {
                         "query": {
-                            "match": {
-                                "unite_legale.liste_dirigeants": {
-                                    "query": terms,
-                                    "operator": "AND",
-                                    "boost": 10,
-                                    "_name": "partial match liste dirigeants",
-                                }
+                            "bool": {
+                                "must": [
+                                    {
+                                        "match": {
+                                            "unite_legale.liste_dirigeants": {
+                                                "query": terms,
+                                                "operator": "AND",
+                                                "boost": 10,
+                                                "_name": "partial match liste dirigeants",
+                                            }
+                                        }
+                                    }
+                                ],
+                                "filter": [
+                                    {
+                                        "bool": {
+                                            "must_not": [
+                                                {
+                                                    "term": {
+                                                        "unite_legale.statut_diffusion_unite_legale": "P"
+                                                    }
+                                                },
+                                            ]
+                                        }
+                                    }
+                                ],
                             }
                         },
                         "field_value_factor": mid_multiplier,

--- a/app/elastic/queries/text.py
+++ b/app/elastic/queries/text.py
@@ -259,6 +259,10 @@ def sort_by_size_text_query(terms: str, matching_size: int):
                                 ],
                                 "filter": [
                                     {
+                                        # Privacy rule:
+                                        # we allow searching `liste_dirigeants` only when diffusion
+                                        # is NOT "P". Without this, a document could match purely
+                                        # because of dirigeants data even when diffusion is "P".
                                         "bool": {
                                             "must_not": [
                                                 {
@@ -551,6 +555,7 @@ def sort_by_nombre_etablissement_query(terms: str, matching_size: int):
                                 ],
                                 "filter": [
                                     {
+                                        # Same gating as above (different scoring/multiplier branch).
                                         "bool": {
                                             "must_not": [
                                                 {

--- a/app/main.py
+++ b/app/main.py
@@ -43,8 +43,8 @@ def custom_openapi():
 
 app.openapi = custom_openapi
 
-# Sentry Integration and Elastic APM Integration for Production and Staging
-if settings.env in ["prod", "staging"]:
+# Sentry Integration and Elastic APM Integration for Production
+if settings.env == "prod":
     apm_client = make_apm_client(settings.apm_config)
     app.add_middleware(ElasticAPM, client=apm_client)
     setup_sentry()

--- a/app/main.py
+++ b/app/main.py
@@ -43,8 +43,8 @@ def custom_openapi():
 
 app.openapi = custom_openapi
 
-# Sentry Integration and Elastic APM Integration for Production
-if settings.env == "prod":
+# Sentry Integration and Elastic APM Integration for Production and Staging
+if settings.env in ["prod", "staging"]:
     apm_client = make_apm_client(settings.apm_config)
     app.add_middleware(ElasticAPM, client=apm_client)
     setup_sentry()


### PR DESCRIPTION
### Problem
`dirigeants` data is not visible results but the siren are included in search results.

### Explanation
 `liste_dirigeants`, `nom_personne` et `prenoms_personne` are still included in text search and person search if personne morale non diffusible.

#### Solution:
- Prevent documents with `unite_legale.statut_diffusion_unite_legale = "P"` from matching via dirigeants fields.
- Make person search deterministic by requiring at least one nested person clause to match (`minimum_should_match=1`) when `type_personne` is used.
- Fyi: ES `nested` scope + `should` semantics and the diffusion gating logic.

#### Test plan
- Call `GET /search?nom_personne=...&prenoms_personne=...&type_personne=dirigeant&minimal=true`
- Verify no results include `statut_diffusion_unite_legale = "P"` due to dirigeants matching.
- Run a standard text search and verify results/ranking still look normal for diffusible entities.