### PR TITLE
feat(es): use the es dsl directly from python client

### DIFF
--- a/app/elastic/es_index.py
+++ b/app/elastic/es_index.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Document
+from elasticsearch.dsl import Document
 
 
 class StructureMapping(Document):

--- a/app/elastic/filters/boolean.py
+++ b/app/elastic/filters/boolean.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Q
+from elasticsearch.dsl import Q
 
 from app.elastic.helpers.elastic_fields import get_elasticsearch_field_name
 

--- a/app/elastic/filters/siret.py
+++ b/app/elastic/filters/siret.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Q
+from elasticsearch.dsl import Q
 
 
 def filter_by_siret(search, siret_string):

--- a/app/elastic/geo_search.py
+++ b/app/elastic/geo_search.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Q
+from elasticsearch.dsl import Q
 
 from app.elastic.filters.term_filters import filter_term_list_search_unite_legale
 from app.elastic.helpers.exclude_etablissements import (

--- a/app/elastic/queries/bilan.py
+++ b/app/elastic/queries/bilan.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import query
+from elasticsearch.dsl import query
 
 from app.elastic.helpers.elastic_fields import get_elasticsearch_field_name
 

--- a/app/elastic/queries/person.py
+++ b/app/elastic/queries/person.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import query
+from elasticsearch.dsl import query
 
 # List of French stop words (from Elasticsearch's _french_ list)
 STOP_WORDS = {

--- a/app/elastic/text_search.py
+++ b/app/elastic/text_search.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Q
+from elasticsearch.dsl import Q
 
 from app.elastic.filters.boolean import (
     filter_search_by_bool_fields_unite_legale,

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 import yaml
 from elasticapm.contrib.starlette import ElasticAPM, make_apm_client
-from elasticsearch_dsl import connections
+from elasticsearch.dsl import connections
 from fastapi import FastAPI, Request
 from fastapi.responses import RedirectResponse
 
@@ -19,7 +19,7 @@ setup_logging()
 # Connect to Elasticsearch
 connections.create_connection(
     hosts=[str(settings.elastic.url)],
-    http_auth=(settings.elastic.user, settings.elastic.password.get_secret_value()),
+    basic_auth=(settings.elastic.user, settings.elastic.password.get_secret_value()),
     retry_on_timeout=True,
 )
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,5 @@
 PyYAML==6.0.2
-elasticsearch==8.13.1
-elasticsearch_dsl==8.13.1
+elasticsearch==9.2.1
 elastic-apm==6.24.0
 requests==2.32.4
 sentry-sdk==2.43.0


### PR DESCRIPTION
closes https://github.com/annuaire-entreprises-data-gouv-fr/search-api/issues/507 
depends on https://github.com/annuaire-entreprises-data-gouv-fr/search-infra/pull/700

* Uninstall the elasticsearch-dsl package

* Install new version elasticsearch 9

* Replace elasticsearch_dsl with elasticsearch.dsl in your imports