### PR TITLE
fix(es9): use from/size instead of slicing (ES9 best practice)

### DIFF
--- a/app/elastic/helpers/helpers.py
+++ b/app/elastic/helpers/helpers.py
@@ -31,18 +31,22 @@ def execute_and_agg_total_results_by_identifiant(es_search_builder):
 
 def page_through_results(es_search_builder):
     """
+        Use from/size instead of slicing (ES9 best practice)
 
-    Args:
-        es_search_builder: ElasticSearchBuilder Instance
-
-    Returns:
-        ElasticSearchBuilder Instance with pagination
+    -    Args:
+    -        es_search_builder: ElasticSearchBuilder Instance
+    -
+    -    Returns:
+    -        ElasticSearchBuilder Instance with pagination
 
     """
+
     size = es_search_builder.search_params.per_page
     offset = (es_search_builder.search_params.page - 1) * size
-    search_client = es_search_builder.es_search_client
-    return search_client[offset : (offset + size)]
+
+    search = es_search_builder.es_search_client
+
+    return search.extra(from_=offset, size=size)
 
 
 def should_get_doc_by_id(es_search_builder):


### PR DESCRIPTION
request `/search?activite_principale=10.71C&region=11&categorie_entreprise=PME&per_page=25&page=284`
caused a 500 error because :
This limit can be set by changing the [index.max_result_window] index level setting.', Result window is too large, from + size must be less than or equal to: [10000] but was [11800]. See the scroll api for a more efficient way to request large data sets. This limit can be set by changing the [index.max_result_window] index level setting.)

In ES-DSL 8, slicing search[a:b] was equivalent to setting from=a, size=b-a. Both were idempotent — calling them twice just overwrote the previous values.

In ES-DSL 9, the slice search[a:b] changed behavior to mean "of the current window, take a sub-slice" — so it compounds:
```
search[5025:5050]          → from=5025, size=25
search[5025:5050] again    → from=5025+5025=10050, size=25  ← stacks!
```
Whereas .extra(from_=offset, size=size) is a direct dict merge into the query body — it just sets the key, so calling it twice should overwrite:
```
.extra(from_=5025, size=25)          → {"from": 5025, "size": 25}
.extra(from_=5025, size=25) again    → {"from": 5025, "size": 25}  ← overwrites
```
So .extra() should be idempotent even in ES 9. Which means if you're still getting 10050 with .extra(), the bug is not the double-slicing anymore — it's purely the self.es_search_client mutation in execute_and_format_es_search:
python# This saves the already-paginated client back to self
self.es_search_client = page_through_results(self)  # ← from_ = 5025 baked in
