### PR TITLE
fix(non-diffusible): hide nom commercial in nom_complet is siege is ND

### DIFF
--- a/app/service/format_search_results.py
+++ b/app/service/format_search_results.py
@@ -28,8 +28,14 @@ from app.utils.helpers import (
 # Helpers
 # -------------------------
 
-def is_unite_legale_non_diffusible(data):
+
+def is_unite_legale_non_diffusible(data) -> bool:
     return data.get("statut_diffusion_unite_legale") == "P"
+
+
+def is_siege_non_diffusible(data) -> bool:
+    siege = get_value(data, "siege")
+    return bool(siege and siege.get("statut_diffusion_etablissement") == "P")
 
 
 # -------------------------
@@ -38,7 +44,8 @@ def is_unite_legale_non_diffusible(data):
 
 
 def build_unite_legale_base(data):
-    is_nd = is_unite_legale_non_diffusible(data)
+    is_ul_nd = is_unite_legale_non_diffusible(data)
+    is_siege_nd = is_siege_non_diffusible(data)
 
     fields = {
         "siren": get_value(data, "siren"),
@@ -47,7 +54,8 @@ def build_unite_legale_base(data):
             get_value(data, "sigle"),
             get_nom_commercial(get_value(data, "siege")),
             get_value(data, "est_personne_morale_insee"),
-            is_nd,
+            is_ul_nd,
+            is_siege_nd,
         ),
         "nom_raison_sociale": get_value(data, "nom_raison_sociale"),
         "sigle": get_value(data, "sigle"),

--- a/app/service/formatters/nom_complet.py
+++ b/app/service/formatters/nom_complet.py
@@ -1,31 +1,28 @@
-def get_nom_commercial(siege):
+def get_nom_commercial(siege: dict | None) -> str | None:
     return siege.get("nom_commercial") if siege else None
 
 
 def format_nom_complet(
-    nom_complet,
-    sigle=None,
-    nom_commercial_siege=None,
-    is_personne_morale_insee=False,
-    is_non_diffusible=False,
-):
-    """Add `denomination usuelle` fields and `sigle` to `nom_complet`.
+    nom_complet: str | None,
+    sigle: str | None = None,
+    nom_commercial_siege: str | None = None,
+    is_personne_morale_insee: bool = False,
+    is_ul_non_diffusible: bool = False,
+    is_siege_non_diffusible: bool = False,
+) -> str | None:
+    """Add `denomination usuelle` fields (if diffusible) and `sigle` to `nom_complet`.
 
     Returns None if nom_complet is empty.
     """
     if not nom_complet:
         return None
 
-    # Build denomination from available sources
-    denomination = None
-    if nom_commercial_siege:
-        denomination = nom_commercial_siege
+    parts = [nom_complet]
 
-    # Build final name with parenthetical additions
-    result = nom_complet
-    if denomination:
-        result += f" ({denomination.strip()})"
-    if sigle and not (is_personne_morale_insee and is_non_diffusible):
-        result += f" ({sigle})"
+    if nom_commercial_siege and not is_siege_non_diffusible:
+        parts.append(f"({nom_commercial_siege.strip()})")
 
-    return result.upper()
+    if sigle and not (is_personne_morale_insee and is_ul_non_diffusible):
+        parts.append(f"({sigle})")
+
+    return " ".join(parts).upper()


### PR DESCRIPTION
For siege non-diffusible, `nom_commercial=[ND]`
This PR checks if `siege` is also ND before adding `nom commercial` to `nom_complet`.
Before: 
<img width="597" height="197" alt="Screenshot 2026-05-04 at 16 30 11" src="https://github.com/user-attachments/assets/d50a1372-3fa8-40c5-ad41-3a74f5b9dff1" />

After:
<img width="544" height="172" alt="Screenshot 2026-05-04 at 16 30 32" src="https://github.com/user-attachments/assets/183776bc-6e3c-40de-ac50-53d5b2f387d5" />
