### PR TITLE
build: remove unused deps

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,12 +3,9 @@ elasticsearch==9.3.0
 elastic-apm==6.25.0
 requests==2.33.0
 sentry-sdk==2.58.0
-python-dotenv==1.2.2
 pytest==9.0.3
 redis==7.0.1
-httpx==0.28.1
 pydantic==2.13.2
 fastapi[standard]==0.136.0
-uvicorn==0.44.0
 orjson==3.11.6
 pydantic-settings==2.13.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,10 @@ dependencies = [
     "fastapi[standard]==0.136.0",
     "orjson==3.11.6",
     "pydantic-settings==2.13.1",
-
 ]
 
 [project.optional-dependencies]
-dev = ["PyYAML==6.0.2", "pytest==9.0.0"]
+dev = ["PyYAML==6.0.2", "pytest==9.0.3"]
 
 [project.urls]
 API = "https://recherche-entreprises.api.gouv.fr/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,9 @@ dependencies = [
     "requests==2.33.0",
     "elastic-apm==6.25.0",
     "sentry-sdk==2.58.0",
-    "python-dotenv==1.2.2",
     "redis==7.0.1",
-    "httpx==0.28.1",
     "pydantic==2.13.2",
     "fastapi[standard]==0.136.0",
-    "uvicorn==0.44.0",
     "orjson==3.11.6",
     "pydantic-settings==2.13.1",
 


### PR DESCRIPTION
`uvicorn`, `httpx` and `python-dotenv` are already sub-dependencies of `fastapi` and we don't use them directly.
This will reduce the risk of mismatched dependency version and will also reduce the volume of dependabot notifications.
Those dependencies maybe used to have bugs that required us to pin their versions but it seems to be no longer the case since all E2E tests are green.