### PR TITLE
chore: update packages and fix fastapi warning

### DIFF
--- a/app/exceptions/exception_handlers.py
+++ b/app/exceptions/exception_handlers.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Callable
 
 from fastapi import FastAPI, Request
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import JSONResponse
 from sentry_sdk import capture_exception, push_scope
 
 from app.exceptions.exceptions import (
@@ -16,10 +16,8 @@ from app.exceptions.exceptions import (
 
 def create_exception_handler(
     status_code: int = 500, initial_detail: str = "Service is unavailable"
-) -> Callable[[Request, SearchApiError], ORJSONResponse]:
-    async def exception_handler(
-        request: Request, exc: SearchApiError
-    ) -> ORJSONResponse:
+) -> Callable[[Request, SearchApiError], JSONResponse]:
+    async def exception_handler(request: Request, exc: SearchApiError) -> JSONResponse:
         detail = {
             "status_code": exc.status_code or status_code,
             "message": exc.message or initial_detail,
@@ -32,7 +30,7 @@ def create_exception_handler(
             #     scope.fingerprint = ["InvalidParamError"]
             logging.info(f"Bad Request: {exc.message}")
 
-        return ORJSONResponse(
+        return JSONResponse(
             status_code=detail["status_code"],
             content={"erreur": detail["message"]},
         )
@@ -40,9 +38,7 @@ def create_exception_handler(
     return exception_handler
 
 
-async def unhandled_exception_handler(
-    request: Request, exc: Exception
-) -> ORJSONResponse:
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     logging.error(f"Unhandled exception occurred: {exc}", exc_info=True)
 
     with push_scope() as scope:

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,11 +1,11 @@
 PyYAML==6.0.2
 elasticsearch==9.3.0
 elastic-apm==6.25.0
-requests==2.33.0
-sentry-sdk==2.58.0
+requests==2.34.1
+sentry-sdk==2.60.0
 pytest==9.0.3
 redis==7.0.1
 pydantic==2.13.2
 fastapi[standard]==0.136.0
 orjson==3.11.6
-pydantic-settings==2.13.1
+pydantic-settings==2.14.1

--- a/app/service/build_api_response.py
+++ b/app/service/build_api_response.py
@@ -1,5 +1,3 @@
-from fastapi.responses import ORJSONResponse
-
 from app.controller.search_params_builder import SearchParamsBuilder
 from app.elastic.es_search_runner import ElasticSearchRunner
 from app.models.response_builder import ResponseBuilder
@@ -9,12 +7,13 @@ from app.utils.matomo import track_event
 def build_api_response(
     request,
     search_type,
-) -> dict[str, int]:
+) -> dict:
     """Create and format API response.
 
     Args:
         request: HTTP request.
         search_type: type of search.
+
     Returns:
         response in json format (results, total_results, page, per_page,
         total_pages)
@@ -23,4 +22,4 @@ def build_api_response(
     search_params = SearchParamsBuilder.extract_params(request, search_type)
     es_search_results = ElasticSearchRunner(search_params, search_type)
     formatted_response = ResponseBuilder(search_params, es_search_results)
-    return ORJSONResponse(content=formatted_response.response)
+    return formatted_response.response

--- a/app/service/formatters/immatriculation.py
+++ b/app/service/formatters/immatriculation.py
@@ -25,7 +25,7 @@ def format_immatriculation(immatriculation):
             capital_variable=get_field("capital_variable"),
             devise_capital=get_field("devise_capital"),
             indicateur_associe_unique=get_field("indicateur_associe_unique"),
-        ).dict()
+        )
 
 
 def format_nature_entreprise(nature_entreprise):

--- a/app/tests/e2e_tests/response_tester.py
+++ b/app/tests/e2e_tests/response_tester.py
@@ -27,7 +27,7 @@ def get_field_value(results, field_name):
 
 class APIResponseTester:
     def __init__(self, api_url):
-        self.api_url = api_url
+        self.api_url = api_url.rstrip("/")
 
     def get_api_response(self, path):
         session = requests.Session()
@@ -35,7 +35,7 @@ class APIResponseTester:
         adapter = HTTPAdapter(max_retries=retry)
         session.mount("http://", adapter)
         session.mount("https://", adapter)
-        response = session.get(url=self.api_url + path)
+        response = session.get(url=f"{self.api_url}/{path.lstrip('/')}")
         return response
 
     def get_api_response_code(self, path):

--- a/app/tests/e2e_tests/test_api.py
+++ b/app/tests/e2e_tests/test_api.py
@@ -321,33 +321,33 @@ def test_egapro_renseignee(api_response_tester):
 
 
 def test_achats_responsables(api_response_tester):
-    path = "/search?est_achats_responsables=true"
+    path = "search?est_achats_responsables=true"
     api_response_tester.test_field_value(
         path, 0, "complements.est_achats_responsables", True
     )
     api_response_tester.test_number_of_results(path, 100)
 
-    path = "/search?est_achats_responsables=false"
+    path = "search?est_achats_responsables=false"
     api_response_tester.test_number_of_results(path, min_total_results_filters)
 
     # Michelin
-    path = "/search?q=855200507"
+    path = "search?q=855200507"
     api_response_tester.test_field_value(
         path, 0, "complements.est_achats_responsables", True
     )
 
 
 def test_alim_confiance(api_response_tester):
-    path = "/search?est_alim_confiance=true"
+    path = "search?est_alim_confiance=true"
     api_response_tester.test_field_value(
         path, 0, "complements.est_alim_confiance", True
     )
     api_response_tester.test_number_of_results(path, min_total_results_filters)
 
-    path = "/search?est_alim_confiance=false"
+    path = "search?est_alim_confiance=false"
     api_response_tester.test_number_of_results(path, min_total_results_filters)
 
-    path = "/search?q=343262622"  # LIDL
+    path = "search?q=343262622"  # LIDL
     api_response_tester.test_field_value(
         path, 0, "complements.est_alim_confiance", True
     )
@@ -749,16 +749,16 @@ def test_siae_filter(api_response_tester):
 
 
 def test_patrimoine_vivant(api_response_tester):
-    path = "/search?est_patrimoine_vivant=true"
+    path = "search?est_patrimoine_vivant=true"
     api_response_tester.test_field_value(
         path, 0, "complements.est_patrimoine_vivant", True
     )
     api_response_tester.test_number_of_results(path, 1000)
 
-    path = "/search?est_patrimoine_vivant=false"
+    path = "search?est_patrimoine_vivant=false"
     api_response_tester.test_number_of_results(path, min_total_results_filters)
 
-    path = "/search?q=397743634"
+    path = "search?q=397743634"
     api_response_tester.test_field_value(
         path, 0, "complements.est_patrimoine_vivant", True
     )
@@ -769,7 +769,7 @@ def test_immatriculation(api_response_tester):
     Test immatriculation object.
     """
     # Test "EDF"
-    path_edf = "/search?q=electricite%20de%20france&include_admin=immatriculation"
+    path_edf = "search?q=electricite%20de%20france&include_admin=immatriculation"
     api_response_tester.assert_api_response_code_200(path_edf)
 
     immatriculation_data_edf = {
@@ -1058,7 +1058,7 @@ def test_est_avocat(api_response_tester):
 
 def test_bodacc(api_response_tester):
     # SIREN 552032534 : entreprise active sans radiation ni procédure collective
-    path = "/search?q=552032534&include_admin=bodacc"
+    path = "search?q=552032534&include_admin=bodacc"
     api_response_tester.assert_api_response_code_200(path)
 
     api_response_tester.test_field_value(path, 0, "bodacc.radiation", None)
@@ -1067,21 +1067,21 @@ def test_bodacc(api_response_tester):
     # SIREN 442750196 : entreprise PP EI, radiée au RCS le 1er juin 2024
     # Mais nouveau établissement avec date de début d'activité au 2016-09-15
     # Donc on considère la date de radiation comme obsolète et doit être masquée
-    path = "/search?q=442750196&include_admin=bodacc"
+    path = "search?q=442750196&include_admin=bodacc"
     api_response_tester.assert_api_response_code_200(path)
 
     api_response_tester.test_field_value(path, 0, "bodacc.radiation", None)
     api_response_tester.test_field_value(path, 0, "bodacc.procedure_collective", None)
 
     # SIREN 448900399 : cas particulier dont les radiations sont masquées par précaution pour le moment
-    path = "/search?q=448900399&include_admin=bodacc"
+    path = "search?q=448900399&include_admin=bodacc"
     api_response_tester.assert_api_response_code_200(path)
 
     api_response_tester.test_field_value(path, 0, "bodacc.radiation", None)
     api_response_tester.test_field_value(path, 0, "bodacc.procedure_collective", None)
 
     # SIREN 776326126 : entreprise PP non EI, nature juridique 2110, radiée RCS mais active SIRENE et RNE
-    path = "/search?q=776326126&include_admin=bodacc"
+    path = "search?q=776326126&include_admin=bodacc"
     api_response_tester.assert_api_response_code_200(path)
 
     api_response_tester.test_field_value(path, 0, "bodacc.radiation.est_radie", True)
@@ -1092,7 +1092,7 @@ def test_bodacc(api_response_tester):
     api_response_tester.test_field_value(path, 0, "bodacc.procedure_collective", None)
 
     # SIREN : entreprise PM, donc sans date de radiation, radiée RCS mais active SIRENE et RNE
-    path = "/search?q=414787754&include_admin=bodacc"
+    path = "search?q=414787754&include_admin=bodacc"
     api_response_tester.assert_api_response_code_200(path)
 
     api_response_tester.test_field_value(path, 0, "bodacc.radiation.est_radie", True)
@@ -1103,7 +1103,7 @@ def test_bodacc(api_response_tester):
     api_response_tester.test_field_value(path, 0, "bodacc.procedure_collective", None)
 
     # SIREN 909324055 : entreprise en procédure collective
-    path = "/search?q=480526862&include_admin=bodacc"
+    path = "search?q=480526862&include_admin=bodacc"
     api_response_tester.assert_api_response_code_200(path)
 
     api_response_tester.test_field_value(path, 0, "bodacc.radiation", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,14 @@ readme = "README.md"
 license-files = ["LICENSE"]
 dependencies = [
     "elasticsearch==9.3.0",
-    "requests==2.33.0",
+    "requests==2.34.2",
     "elastic-apm==6.25.0",
-    "sentry-sdk==2.58.0",
+    "sentry-sdk==2.60.0",
     "redis==7.0.1",
     "pydantic==2.13.2",
     "fastapi[standard]==0.136.0",
     "orjson==3.11.6",
-    "pydantic-settings==2.13.1",
+    "pydantic-settings==2.14.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Requests 2.34+ no longer silently collapses double slashes in URLs.
Some test paths had a leading slash (e.g. `/search?...`) while others did not, causing double slashes when concatenated with the base URL (`http://localhost:8000/`), resulting in 404s.

Strip the trailing slash from the base URL at construction time and normalize the path's leading slash in `get_api_response`, so both formats resolve correctly without touching any test files.

https://requests.readthedocs.io/en/latest/community/updates/#id3

> Requests no longer incorrectly strips duplicate leading slashes in URI paths. This should address user issues with specific presigned URLs. Note the full fix requires urllib3 2.7.0+. (#7315)
