### PR TITLE
fix: es long overflow on chiffre d'affaire filters

### DIFF
--- a/app/controller/search_params_model.py
+++ b/app/controller/search_params_model.py
@@ -125,6 +125,10 @@ class SearchParams(BaseModel):
         "radius",
         "lat",
         "lon",
+        "ca_min",
+        "ca_max",
+        "resultat_net_min",
+        "resultat_net_max",
         mode="after",
     )
     # Apply after first validator and Pydantic internal validation

--- a/app/tests/e2e_tests/test_api.py
+++ b/app/tests/e2e_tests/test_api.py
@@ -1175,3 +1175,37 @@ def test_acces_espace_agent(api_response_tester):
     api_response_tester.test_field_value(
         path, 0, "complements.est_administration", False
     )
+
+
+def test_ca_max_out_of_range_returns_400(api_response_tester):
+    """
+    Test that providing a ca_max value exceeding the long integer range returns a 400 error.
+    """
+    path = "search?ca_max=1000000000000000000000"
+    api_response_tester.assert_api_response_code_400(path)
+    response = api_response_tester.get_api_response(path)
+    assert response.json()["erreur"] == (
+        "Veuillez indiquer un paramètre `ca_max` entre `-9223372036854775295` et "
+        "`9223372036854775295`, par défaut `None`."
+    )
+
+
+def test_ca_min_out_of_range_returns_400(api_response_tester):
+    """
+    Test that providing a ca_min value exceeding the long integer range returns a 400 error.
+    """
+    path = "search?ca_min=1000000000000000000000"
+    api_response_tester.assert_api_response_code_400(path)
+    response = api_response_tester.get_api_response(path)
+    assert response.json()["erreur"] == (
+        "Veuillez indiquer un paramètre `ca_min` entre `-9223372036854775295` et "
+        "`9223372036854775295`, par défaut `None`."
+    )
+
+
+def test_ca_valid_values_return_200(api_response_tester):
+    """
+    Test that valid ca_min / ca_max values within long range return 200.
+    """
+    path = "search?ca_min=0&ca_max=1000000"
+    api_response_tester.assert_api_response_code_200(path)


### PR DESCRIPTION
[Sentry error](https://errors.data.gouv.fr/organizations/sentry/issues/294484/?environment=production&project=14&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=1&utc=true).

https://recherche-entreprises.api.gouv.fr/search?ca_max=1000000000000000000000 returns a 500.

Fixes a Sentry error (search_phase_execution_exception) triggered when values exceeding the ES long integer range (~9.2×10¹⁸) were passed to ca_min, ca_max, resultat_net_min or resultat_net_max. Added range validation that returns a 400 before the query reaches Elasticsearch.